### PR TITLE
Add Plezi as middleware

### DIFF
--- a/apps/web/config/routes.rb
+++ b/apps/web/config/routes.rb
@@ -2,4 +2,4 @@
 # See: http://hanamirb.org/guides/routing/overview/
 #
 # Example:
-# get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }
+get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,15 @@
 require './config/environment'
+require 'plezi'
 
+class Controller
+  def index
+    'Hello from Plezi!'
+  end
+end
+
+Plezi.route '/plezi', Controller
+
+app = proc { |_env| [200, { 'Content-Length' => '11' }, ['Hello Rack!']] }
+
+use Plezi
 run Hanami.app

--- a/config.ru
+++ b/config.ru
@@ -9,7 +9,5 @@ end
 
 Plezi.route '/plezi', Controller
 
-app = proc { |_env| [200, { 'Content-Length' => '11' }, ['Hello Rack!']] }
-
 use Plezi
 run Hanami.app


### PR DESCRIPTION
The documentation for this was incredibly vague and somewhat
non-existent. The outcome of this is as expected though. We specify a
route to the Plezi controller for websocket connections to reach at
`/plezi`. We add a route in `routes.rb` at `/hello` to demonstrate that we are
in fact able to build our Hanami project with Plezi.