### PR TITLE
Create a base endpoint for a list of players

### DIFF
--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -3,3 +3,6 @@
 #
 # Example:
 # get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }
+get '/players', to: 'players#list'
+# get '/players/list', to: 'players#list' was the default generation, keeping it
+# to think about later

--- a/apps/api/controllers/players/list.rb
+++ b/apps/api/controllers/players/list.rb
@@ -1,0 +1,12 @@
+module Api
+  module Controllers
+    module Players
+      class List
+        include Api::Action
+
+        def call(params)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/controllers/players/list.rb
+++ b/apps/api/controllers/players/list.rb
@@ -3,8 +3,12 @@ module Api
     module Players
       class List
         include Api::Action
+        accept :json
+
+        expose :players
 
         def call(params)
+          @players = PlayerRepository.new.all
         end
       end
     end

--- a/apps/api/views/players/list.rb
+++ b/apps/api/views/players/list.rb
@@ -3,6 +3,11 @@ module Api
     module Players
       class List
         include Api::View
+        layout false
+
+        def render
+          _raw JSON.dump(players.map(&:to_h))
+        end
       end
     end
   end

--- a/apps/api/views/players/list.rb
+++ b/apps/api/views/players/list.rb
@@ -1,0 +1,9 @@
+module Api
+  module Views
+    module Players
+      class List
+        include Api::View
+      end
+    end
+  end
+end

--- a/db/migrations/20190624225737_create_players.rb
+++ b/db/migrations/20190624225737_create_players.rb
@@ -1,0 +1,9 @@
+Hanami::Model.migration do
+  change do
+    create_table :players do
+      primary_key :id
+
+      column :player_id, Integer
+    end
+  end
+end

--- a/lib/typinggame_server/entities/player.rb
+++ b/lib/typinggame_server/entities/player.rb
@@ -1,0 +1,3 @@
+class Player < Hanami::Entity
+  attributes :player_id
+end

--- a/lib/typinggame_server/repositories/player_repository.rb
+++ b/lib/typinggame_server/repositories/player_repository.rb
@@ -1,0 +1,2 @@
+class PlayerRepository < Hanami::Repository
+end

--- a/spec/api/controllers/players/list_spec.rb
+++ b/spec/api/controllers/players/list_spec.rb
@@ -1,18 +1,1 @@
-require 'api_helper'
-
-describe 'List of players' do
-  it 'is successful' do
-    header 'Content-Type', 'application/json;'
-    get '/api/players'
-
-    expect(last_response).must_be :ok?
-    expect(last_response.content_type).must_include 'application/json'
-  end
-
-  it 'is empty by default' do
-    header 'Content-Type', 'application/json;'
-    get '/api/players'
-
-    expect(last_repsonse.body).must_equal '[]'
-  end
-end
+require 'spec_helper'

--- a/spec/api/controllers/players/list_spec.rb
+++ b/spec/api/controllers/players/list_spec.rb
@@ -1,0 +1,18 @@
+require 'api_helper'
+
+describe 'List of players' do
+  it 'is successful' do
+    header 'Content-Type', 'application/json;'
+    get '/api/players'
+
+    expect(last_response).must_be :ok?
+    expect(last_response.content_type).must_include 'application/json'
+  end
+
+  it 'is empty by default' do
+    header 'Content-Type', 'application/json;'
+    get '/api/players'
+
+    expect(last_repsonse.body).must_equal '[]'
+  end
+end

--- a/spec/api/views/players/list_spec.rb
+++ b/spec/api/views/players/list_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::Views::Players::List, type: :view do
+  let(:exposures) { Hash[format: :html] }
+  let(:template)  { Hanami::View::Template.new('apps/api/templates/players/list.html.erb') }
+  let(:view)      { described_class.new(template, exposures) }
+  let(:rendered)  { view.render }
+
+  it 'exposes #format' do
+    expect(view.format).to eq exposures.fetch(:format)
+  end
+end

--- a/spec/typinggame_server/entities/player_spec.rb
+++ b/spec/typinggame_server/entities/player_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe Player, type: :entity do
+  # place your tests here
+end

--- a/spec/typinggame_server/repositories/player_repository_spec.rb
+++ b/spec/typinggame_server/repositories/player_repository_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe PlayerRepository, type: :repository do
+  # place your tests here
+end


### PR DESCRIPTION
This PR is a bit of a mess because I had to work with a lot of files and I wasn't really sure which files get committed with each other and what really counts as a unit of work. It will all come together as I start to understand Hanami better.

If I manually add an entry to the `players` table in psql then navigate to `http://localhost:2300/api/players` I will see `[{"id":1,"player_id":1}]`. I didn't realize it also gives you the `primary_key` so maybe I don't actually need a `player_id` column.

A player will of course have more columns, this was just a proof of concept to show that it works.

