### PR TITLE
Add player by :id endpoint

### DIFF
--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -4,3 +4,4 @@
 # Example:
 # get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }
 get '/players', to: 'players#index'
+get '/players/:id', to: 'players#show'

--- a/apps/api/controllers/players/show.rb
+++ b/apps/api/controllers/players/show.rb
@@ -1,0 +1,12 @@
+module Api
+  module Controllers
+    module Players
+      class Show
+        include Api::Action
+
+        def call(params)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/controllers/players/show.rb
+++ b/apps/api/controllers/players/show.rb
@@ -12,7 +12,7 @@ module Api
 
         def call(params)
           player = @interactor.call(params[:id]).player
-          halt 400 && self.status = 400 unless !player.nil?
+          halt 400 && self.status = 400 if player.nil?
           @player = player
         end
       end

--- a/apps/api/controllers/players/show.rb
+++ b/apps/api/controllers/players/show.rb
@@ -4,7 +4,16 @@ module Api
       class Show
         include Api::Action
 
+        expose :player
+
+        def initialize(interactor: Interactors::Players::FetchPlayer.new)
+          @interactor = interactor
+        end
+
         def call(params)
+          player = @interactor.call(params[:id]).player
+          halt 400 && self.status = 400 unless !player.nil?
+          @player = player
         end
       end
     end

--- a/apps/api/controllers/players/show.rb
+++ b/apps/api/controllers/players/show.rb
@@ -12,7 +12,7 @@ module Api
 
         def call(params)
           player = @interactor.call(params[:id]).player
-          halt 400 && self.status = 400 if player.nil?
+          halt 404 if player.nil?
           @player = player
         end
       end

--- a/apps/api/views/players/show.rb
+++ b/apps/api/views/players/show.rb
@@ -1,0 +1,9 @@
+module Api
+  module Views
+    module Players
+      class Show
+        include Api::View
+      end
+    end
+  end
+end

--- a/apps/api/views/players/show.rb
+++ b/apps/api/views/players/show.rb
@@ -3,6 +3,10 @@ module Api
     module Players
       class Show
         include Api::View
+
+        def render
+          raw JSON.generate({ id: player.id })
+        end
       end
     end
   end

--- a/lib/typinggame_server/interactors/players/fetch_player.rb
+++ b/lib/typinggame_server/interactors/players/fetch_player.rb
@@ -1,0 +1,19 @@
+require 'hanami/interactor'
+
+module Interactors
+  module Players
+    class FetchPlayer
+      include Hanami::Interactor
+
+      expose :player
+
+      def initialize(repository: PlayerRepository.new)
+        @players_repository = repository
+      end
+
+      def call(params)
+        @player = @players_repository.find(params)
+      end
+    end
+  end
+end

--- a/spec/api/controllers/players/show_spec.rb
+++ b/spec/api/controllers/players/show_spec.rb
@@ -8,25 +8,25 @@ RSpec.describe Api::Controllers::Players::Show, type: :action do
   let(:action) { described_class.new(interactor: interactor) }
 
   context "the player doesn't exist" do
-    before { repository.clear }
-
     it 'is unsuccessful' do
       response = action.call(id: 1)
-      expect(response[0]).to eq(400)
+      status_code = response[0]
+
+      expect(status_code).to eq(404)
     end
   end
 
   context 'the player exists' do
     before do
-      repository.clear
       repository.create(id: '1')
       repository.create(id: '2')
     end
 
     it 'is successful' do
       response = action.call(id: 1)
+      status_code = response[0]
 
-      expect(response[0]).to eq(200)
+      expect(status_code).to eq(200)
     end
 
     it 'exposes a player' do

--- a/spec/api/controllers/players/show_spec.rb
+++ b/spec/api/controllers/players/show_spec.rb
@@ -1,9 +1,38 @@
-RSpec.describe Api::Controllers::Players::Show, type: :action do
-  let(:action) { described_class.new }
-  let(:params) { Hash[] }
+require 'spec_helper'
 
-  it 'is successful' do
-    response = action.call(params)
-    expect(response[0]).to eq 200
+RSpec.describe Api::Controllers::Players::Show, type: :action do
+  let(:repository) { PlayerRepository.new }
+  let(:interactor) do
+    Interactors::Players::FetchPlayer.new(repository: repository)
+  end
+  let(:action) { described_class.new(interactor: interactor) }
+
+  context "the player doesn't exist" do
+    before { repository.clear }
+
+    it 'is unsuccessful' do
+      response = action.call(id: 1)
+      expect(response[0]).to eq(400)
+    end
+  end
+
+  context 'the player exists' do
+    before do
+      repository.clear
+      repository.create(id: '1')
+      repository.create(id: '2')
+    end
+
+    it 'is successful' do
+      response = action.call(id: 1)
+
+      expect(response[0]).to eq(200)
+    end
+
+    it 'exposes a player' do
+      action.call(id: 1)
+
+      expect(action.player.id).to eq(1)
+    end
   end
 end

--- a/spec/api/controllers/players/show_spec.rb
+++ b/spec/api/controllers/players/show_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Api::Controllers::Players::Show, type: :action do
+  let(:action) { described_class.new }
+  let(:params) { Hash[] }
+
+  it 'is successful' do
+    response = action.call(params)
+    expect(response[0]).to eq 200
+  end
+end

--- a/spec/api/views/players/show_spec.rb
+++ b/spec/api/views/players/show_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::Views::Players::Show, type: :view do
+  let(:exposures) { Hash[format: :html] }
+  let(:template)  { Hanami::View::Template.new('apps/api/templates/players/show.html.erb') }
+  let(:view)      { described_class.new(template, exposures) }
+  let(:rendered)  { view.render }
+
+  it 'exposes #format' do
+    expect(view.format).to eq exposures.fetch(:format)
+  end
+end

--- a/spec/api/views/players/show_spec.rb
+++ b/spec/api/views/players/show_spec.rb
@@ -1,10 +1,20 @@
-RSpec.describe Api::Views::Players::Show, type: :view do
-  let(:exposures) { Hash[format: :html] }
-  let(:template)  { Hanami::View::Template.new('apps/api/templates/players/show.html.erb') }
-  let(:view)      { described_class.new(template, exposures) }
-  let(:rendered)  { view.render }
+require 'spec_helper'
 
-  it 'exposes #format' do
-    expect(view.format).to eq exposures.fetch(:format)
+RSpec.describe Api::Views::Players::Show, type: :view do
+  let(:exposures) { Hash[player: []] }
+  let(:view) { described_class.new(nil, exposures) }
+  let(:rendered) { view.render }
+
+  context 'when a player has been given' do
+    let(:player) { Player.new(id: '2') }
+    let(:exposures) { Hash[player: player] }
+
+    it 'lists the player' do
+      expect(rendered).to include('2')
+    end
+
+    it 'lists it as json' do
+      expect(rendered).to eq({ "id": 2 }.to_json)
+    end
   end
 end

--- a/spec/typinggame_server/interactors/players/fetch_player_spec.rb
+++ b/spec/typinggame_server/interactors/players/fetch_player_spec.rb
@@ -6,13 +6,11 @@ describe Interactors::Players::FetchPlayer do
   let(:params) { 1 }
 
   before do
-    repository.clear
-
     repository.create(id: '1')
     repository.create(id: '2')
   end
 
-  context 'good input' do
+  context 'When the player exists' do
     let(:result) { interactor.call(params) }
 
     it 'succeeds' do

--- a/spec/typinggame_server/interactors/players/fetch_player_spec.rb
+++ b/spec/typinggame_server/interactors/players/fetch_player_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Interactors::Players::FetchPlayer do
+  let(:repository) { PlayerRepository.new }
+  let(:interactor) { described_class.new(repository: repository) }
+  let(:params) { 1 }
+
+  before do
+    repository.clear
+
+    repository.create(id: '1')
+    repository.create(id: '2')
+  end
+
+  context 'good input' do
+    let(:result) { interactor.call(params) }
+
+    it 'succeeds' do
+      expect(result.successful?).to be(true)
+    end
+
+    it 'fetches a player by id' do
+      expect(result.player.id).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
We can `GET` a specific player by `:id` by following the route ie. `/players/4`.
We also handle the error when a player does not exist.