### PR TITLE
Add database_cleaner gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test, :development do
 end
 
 group :test do
+  gem 'database_cleaner'
   gem 'rspec'
   gem 'capybara'
 end

--- a/spec/api/controllers/players/index_spec.rb
+++ b/spec/api/controllers/players/index_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Api::Controllers::Players::Index, type: :action do
   let(:params) { Hash[] }
 
   before do
-    repository.clear
-
     repository.create(id: '1')
     repository.create(id: '2')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,14 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  config
+    .before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) { |example| DatabaseCleaner.cleaning { example.run } }
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods

--- a/spec/typinggame_server/interactors/players/fetch_all_players_spec.rb
+++ b/spec/typinggame_server/interactors/players/fetch_all_players_spec.rb
@@ -5,8 +5,6 @@ describe Interactors::Players::FetchAllPlayers do
   let(:interactor) { described_class.new(repository: repository) }
 
   before do
-    repository.clear
-
     repository.create(id: '1')
     repository.create(id: '2')
   end


### PR DESCRIPTION
This lets us clean up our code and ensures that we don't forget to clean our database before and after testing.

specs for PR #11 will need to updated if/when this is merged.