### PR TITLE
Add endpoint to create a Player entity

### DIFF
--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -4,3 +4,4 @@
 # Example:
 # get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }
 get '/players', to: 'players#index'
+post '/players', to: 'players#create'

--- a/apps/api/controllers/players/create.rb
+++ b/apps/api/controllers/players/create.rb
@@ -1,0 +1,12 @@
+module Api
+  module Controllers
+    module Players
+      class Create
+        include Api::Action
+
+        def call(params)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/controllers/players/create.rb
+++ b/apps/api/controllers/players/create.rb
@@ -4,7 +4,14 @@ module Api
       class Create
         include Api::Action
 
-        def call(params)
+        expose :player
+
+        def initialize(interactor: Interactors::Players::CreatePlayer.new)
+          @interactor = interactor
+        end
+
+        def call(_params)
+          @player = @interactor.call.player
         end
       end
     end

--- a/apps/api/views/players/create.rb
+++ b/apps/api/views/players/create.rb
@@ -1,0 +1,9 @@
+module Api
+  module Views
+    module Players
+      class Create
+        include Api::View
+      end
+    end
+  end
+end

--- a/apps/api/views/players/create.rb
+++ b/apps/api/views/players/create.rb
@@ -3,6 +3,10 @@ module Api
     module Players
       class Create
         include Api::View
+
+        def render
+          raw JSON.generate({ uuid: player.token })
+        end
       end
     end
   end

--- a/lib/typinggame_server/interactors/players/create_player.rb
+++ b/lib/typinggame_server/interactors/players/create_player.rb
@@ -1,0 +1,10 @@
+require 'hanami/interactor'
+
+module Interactors
+  module Players
+    class CreatePlayer
+      include Hanami::Interactor
+      def call(params); end
+    end
+  end
+end

--- a/lib/typinggame_server/interactors/players/create_player.rb
+++ b/lib/typinggame_server/interactors/players/create_player.rb
@@ -1,10 +1,20 @@
 require 'hanami/interactor'
+require 'securerandom'
 
 module Interactors
   module Players
     class CreatePlayer
       include Hanami::Interactor
-      def call(params); end
+
+      expose :player
+
+      def initialize(repository: PlayerRepository.new)
+        @players_repository = repository
+      end
+
+      def call
+        @player = @players_repository.create(token: SecureRandom.uuid)
+      end
     end
   end
 end

--- a/spec/api/controllers/players/create_spec.rb
+++ b/spec/api/controllers/players/create_spec.rb
@@ -1,9 +1,21 @@
 RSpec.describe Api::Controllers::Players::Create, type: :action do
-  let(:action) { described_class.new }
+  let(:repository) { PlayerRepository.new }
+  let(:interactor) do
+    Interactors::Players::CreatePlayer.new(repository: repository)
+  end
+  let(:action) { described_class.new(interactor: interactor) }
   let(:params) { Hash[] }
 
-  it 'is successful' do
-    response = action.call(params)
-    expect(response[0]).to eq 200
+  context 'good input' do
+    it 'is successful' do
+      response = action.call(params)
+
+      expect(response[0]).to eq(200)
+    end
+
+    it 'exposes a player' do
+      action.call(params)
+      expect(action.player).to have_attributes(id: Integer)
+    end
   end
 end

--- a/spec/api/controllers/players/create_spec.rb
+++ b/spec/api/controllers/players/create_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Api::Controllers::Players::Create, type: :action do
+  let(:action) { described_class.new }
+  let(:params) { Hash[] }
+
+  it 'is successful' do
+    response = action.call(params)
+    expect(response[0]).to eq 200
+  end
+end

--- a/spec/api/controllers/players/create_spec.rb
+++ b/spec/api/controllers/players/create_spec.rb
@@ -6,16 +6,14 @@ RSpec.describe Api::Controllers::Players::Create, type: :action do
   let(:action) { described_class.new(interactor: interactor) }
   let(:params) { Hash[] }
 
-  context 'good input' do
-    it 'is successful' do
-      response = action.call(params)
+  it 'is successful' do
+    response = action.call(params)
 
-      expect(response[0]).to eq(200)
-    end
+    expect(response[0]).to eq(200)
+  end
 
-    it 'exposes a player' do
-      action.call(params)
-      expect(action.player).to have_attributes(id: Integer)
-    end
+  it 'exposes a player' do
+    action.call(params)
+    expect(action.player).to have_attributes(id: Integer)
   end
 end

--- a/spec/api/views/players/create_spec.rb
+++ b/spec/api/views/players/create_spec.rb
@@ -1,10 +1,18 @@
-RSpec.describe Api::Views::Players::Create, type: :view do
-  let(:exposures) { Hash[format: :html] }
-  let(:template)  { Hanami::View::Template.new('apps/api/templates/players/create.html.erb') }
-  let(:view)      { described_class.new(template, exposures) }
-  let(:rendered)  { view.render }
+require 'spec_helper'
+require 'securerandom'
 
-  it 'exposes #format' do
-    expect(view.format).to eq exposures.fetch(:format)
+RSpec.describe Api::Views::Players::Create, type: :view do
+  let(:exposures) { Hash[player: []] }
+  let(:view) { described_class.new(nil, exposures) }
+  let(:rendered) { view.render }
+
+  context 'when there are players' do
+    let(:uuid) { SecureRandom.uuid }
+    let(:player) { Player.new(token: uuid) }
+    let(:exposures) { Hash[player: player] }
+
+    it 'lists the UUID as json' do
+      expect(rendered).to eq({ "uuid": uuid }.to_json)
+    end
   end
 end

--- a/spec/api/views/players/create_spec.rb
+++ b/spec/api/views/players/create_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Api::Views::Players::Create, type: :view do
+  let(:exposures) { Hash[format: :html] }
+  let(:template)  { Hanami::View::Template.new('apps/api/templates/players/create.html.erb') }
+  let(:view)      { described_class.new(template, exposures) }
+  let(:rendered)  { view.render }
+
+  it 'exposes #format' do
+    expect(view.format).to eq exposures.fetch(:format)
+  end
+end

--- a/spec/typinggame_server/interactors/players/create_player_spec.rb
+++ b/spec/typinggame_server/interactors/players/create_player_spec.rb
@@ -3,4 +3,16 @@ require 'spec_helper'
 describe Interactors::Players::CreatePlayer do
   let(:repository) { PlayerRepository.new }
   let(:interactor) { described_class.new(repository: repository) }
+
+  context 'good input' do
+    let(:result) { interactor.call }
+
+    it 'succeeds' do
+      expect(result.successful?).to be(true)
+    end
+
+    it 'creates a player' do
+      expect(result.player).to have_attributes(id: Integer)
+    end
+  end
 end

--- a/spec/typinggame_server/interactors/players/create_player_spec.rb
+++ b/spec/typinggame_server/interactors/players/create_player_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Interactors::Players::CreatePlayer do
+  let(:repository) { PlayerRepository.new }
+  let(:interactor) { described_class.new(repository: repository) }
+end

--- a/spec/typinggame_server/interactors/players/create_player_spec.rb
+++ b/spec/typinggame_server/interactors/players/create_player_spec.rb
@@ -3,16 +3,13 @@ require 'spec_helper'
 describe Interactors::Players::CreatePlayer do
   let(:repository) { PlayerRepository.new }
   let(:interactor) { described_class.new(repository: repository) }
+  let(:result) { interactor.call }
 
-  context 'good input' do
-    let(:result) { interactor.call }
+  it 'succeeds' do
+    expect(result.successful?).to be(true)
+  end
 
-    it 'succeeds' do
-      expect(result.successful?).to be(true)
-    end
-
-    it 'creates a player' do
-      expect(result.player).to have_attributes(id: Integer)
-    end
+  it 'creates a player' do
+    expect(result.player).to have_attributes(id: Integer)
   end
 end


### PR DESCRIPTION
We generate Player entities by making a post request that generates a UUID for each player generated.
This UUID will be required by the client to make future requests that require validation, such as deletion or setting their location in the game.