### PR TITLE
Add endpoint to delete a Player entity by UUID

### DIFF
--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -4,3 +4,4 @@
 # Example:
 # get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }
 get '/players', to: 'players#index'
+delete '/players', to: 'players#destroy'

--- a/apps/api/controllers/players/destroy.rb
+++ b/apps/api/controllers/players/destroy.rb
@@ -4,7 +4,15 @@ module Api
       class Destroy
         include Api::Action
 
-        def call(params)
+        def initialize(interactor: Interactors::Players::DestroyPlayer.new)
+          @interactor = interactor
+        end
+
+        def call(_params)
+          uuid = request.env['HTTP_UUID']
+
+          player = @interactor.call(uuid).player
+          halt 400 && self.status = 400 if player.nil?
         end
       end
     end

--- a/apps/api/controllers/players/destroy.rb
+++ b/apps/api/controllers/players/destroy.rb
@@ -1,0 +1,12 @@
+module Api
+  module Controllers
+    module Players
+      class Destroy
+        include Api::Action
+
+        def call(params)
+        end
+      end
+    end
+  end
+end

--- a/lib/typinggame_server/interactors/players/destroy_player.rb
+++ b/lib/typinggame_server/interactors/players/destroy_player.rb
@@ -1,0 +1,23 @@
+require 'hanami/interactor'
+
+module Interactors
+  module Players
+    class DestroyPlayer
+      include Hanami::Interactor
+
+      expose :player
+
+      def initialize(repository: PlayerRepository.new)
+        @players_repository = repository
+      end
+
+      def call(params)
+        @player = @players_repository.find_by_token(token: params)
+
+        return nil if @player.nil?
+
+        @players_repository.delete(@player.id)
+      end
+    end
+  end
+end

--- a/lib/typinggame_server/repositories/players_repository.rb
+++ b/lib/typinggame_server/repositories/players_repository.rb
@@ -1,1 +1,7 @@
-class PlayerRepository < Hanami::Repository; end
+class PlayerRepository < Hanami::Repository
+  def find_by_token(token: token)
+    players.where(token: token).to_a.first
+  rescue => e
+    return nil
+  end
+end

--- a/spec/api/controllers/players/destroy_spec.rb
+++ b/spec/api/controllers/players/destroy_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Api::Controllers::Players::Destroy, type: :action do
+  let(:action) { described_class.new }
+  let(:params) { Hash[] }
+
+  it 'is successful' do
+    response = action.call(params)
+    expect(response[0]).to eq 200
+  end
+end

--- a/spec/api/controllers/players/destroy_spec.rb
+++ b/spec/api/controllers/players/destroy_spec.rb
@@ -1,9 +1,40 @@
-RSpec.describe Api::Controllers::Players::Destroy, type: :action do
-  let(:action) { described_class.new }
-  let(:params) { Hash[] }
+require 'spec_helper'
+require 'securerandom'
 
-  it 'is successful' do
-    response = action.call(params)
-    expect(response[0]).to eq 200
+RSpec.describe Api::Controllers::Players::Destroy, type: :action do
+  let(:repository) { PlayerRepository.new }
+  let(:interactor) do
+    Interactors::Players::DestroyPlayer.new(repository: repository)
+  end
+  let(:action) { described_class.new(interactor: interactor) }
+  let(:uuid) { SecureRandom.uuid }
+
+  context 'nil input' do
+    let(:params) { Hash['HTTP_UUID' => nil] }
+
+    it 'is unsuccessful' do
+      response = action.call(params)
+      expect(response[0]).to eq(400)
+    end
+  end
+
+  context 'improper input' do
+    let(:params) { Hash['HTTP_UUID' => '2bbca412-65cc-4e35-a5b3-6a0a0fd'] }
+
+    it 'is unsuccessful' do
+      response = action.call(params)
+      expect(response[0]).to eq(400)
+    end
+  end
+
+  context 'good input' do
+    let(:params) { Hash['HTTP_UUID' => uuid] }
+    before { repository.create(id: '5', token: uuid) }
+
+    it 'is successful' do
+      response = action.call(params)
+      expect(response[0]).to eq(200)
+      expect(repository.find(5)).to eq(nil)
+    end
   end
 end

--- a/spec/typinggame_server/interactors/players/destroy_player_spec.rb
+++ b/spec/typinggame_server/interactors/players/destroy_player_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'securerandom'
+
+describe Interactors::Players::DestroyPlayer do
+  let(:repository) { PlayerRepository.new }
+  let(:interactor) { described_class.new(repository: repository) }
+  let(:uuid) { SecureRandom.uuid }
+
+  before { repository.create(id: '1', token: uuid) }
+
+  context 'nil input' do
+    let(:result) { interactor.call(nil) }
+
+    it 'is unsuccessful' do
+      expect(result.player).to be(nil)
+    end
+  end
+
+  context 'bad input' do
+    let(:result) { interactor.call('2bbca412-65cc-4e35-a5b3-6a0a0fd') }
+
+    it 'is unsuccessful' do
+      expect(result.player).to be(nil)
+    end
+  end
+
+  context 'good input' do
+    it 'deletes the player by ID' do
+      interactor.call(uuid)
+      expect(repository.find_by_token(token: uuid)).to be(nil)
+    end
+  end
+end

--- a/spec/typinggame_server/repositories/players_repository_spec.rb
+++ b/spec/typinggame_server/repositories/players_repository_spec.rb
@@ -1,3 +1,32 @@
 RSpec.describe PlayerRepository, type: :repository do
-  # place your tests here
+  let(:repository) { PlayerRepository.new }
+  let(:uuid) { SecureRandom.uuid }
+
+  before { @player = repository.create(id: '1', token: uuid) }
+
+  context 'nil input' do
+    let(:result) { repository.find_by_token(token: nil) }
+
+    it 'is unsuccessful' do
+      expect(result).to be(nil)
+    end
+  end
+
+  context 'bad input' do
+    let(:result) do
+      repository.find_by_token(token: '2bbca412-65cc-4e35-a5b3-6a0a0fd')
+    end
+
+    it 'is unsuccessful' do
+      expect(result).to be(nil)
+    end
+  end
+
+  context 'good input' do
+    let(:result) { repository.find_by_token(token: uuid) }
+
+    it 'returns the player' do
+      expect(result).to eq(@player)
+    end
+  end
 end


### PR DESCRIPTION
We only allow a player to be deleted by UUID because this value should be unique and only known to the player it was assigned to. In the future a player might have something like this associated with their account, but for now a UUID is handed out to each player in the repository.

We maintain the single responsibility principle by again removing business logic from the action and placing it in an interactor.