### PR TITLE
Add Plezi and Websocket Controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'hanami-model', '~> 1.3'
 gem 'rubocop'
 gem 'prettier'
 gem 'pry'
+gem 'plezi'
 
 gem 'pg'
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,6 +6,8 @@ require_relative '../apps/web/application'
 require_relative '../apps/api/application'
 
 Hanami.configure do
+  middleware.use Plezi
+
   mount Api::Application, at: '/api'
   mount Web::Application, at: '/'
 

--- a/config/initializers/plezi_init.rb
+++ b/config/initializers/plezi_init.rb
@@ -1,0 +1,42 @@
+require 'plezi'
+
+class WebsocketController
+  # every request that routes to this controller will create a new instance
+  def initialize; end
+  # Http methods are available
+  def index
+    'Hello World!'
+  end
+  # RESTful methods are available
+  def show
+    "showing object with id: #{params['id']}..."
+  end
+  # called before the protocol is swithed from HTTP to WebSockets.
+  #
+  # this allows setting headers, cookies and other data (such as authentication)
+  # prior to opening a WebSocket.
+  #
+  # if the method returns false, the connection will be refused and the remaining routes will be attempted.
+  def pre_connect
+    true
+  end
+  # called immediately after a WebSocket connection has been established.
+  # it blocks all the connection's actions until the `on_open` initialization is finished.
+  def on_open; end
+  # called when new data is recieved
+  #
+  # data is a string that contains binary or UTF8 (message dependent) data.
+  def on_message(data)
+    puts "Websocket got: #{data}"
+    write "echo: #{data}"
+  end
+  # called once, AFTER the connection was closed.
+  def on_close; end
+  # called once, during **server shutdown**, BEFORE the connection is closed.
+  # this will only be called for connections that are open while the server is shutting down.
+  def on_shutdown
+    write 'Server shutting down. Goodbye.'
+  end
+end
+
+Plezi.route '/ws', WebsocketController


### PR DESCRIPTION
With this, I am able to hit the `/ws` route. If I throw a `binding.pry` in the `initializer`, `index`, or `pre_connect` methods I can see that it catches. I am also able to visit the route at `/ws` and see `'Hello World!`.

My client (which I've confirmed works with this Websocket Controller as standalone in its own ruby file) can't establish a connection. When my client attempts the connection this is seen in the console server console:
```
Plezi 0.16.4 as Middleware
Running Plezi version: 0.16.4
[typinggame_server] [INFO] [2019-07-03 09:35:27 -0700] HTTP/1.1 GET 200 ::1 /ws - {} 0.002043
```
So you can see that something is hitting it. A big question I might be asking is where the controller code should be located in the project?