### PR TITLE
Implement Websocket support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'hanami-model', '~> 1.3'
 gem 'rubocop'
 gem 'prettier'
 gem 'pry'
+gem 'iodine'
 
 gem 'pg'
 

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,39 @@
 require './config/environment'
 
+class WebsocketController
+  def on_open(client)
+    puts 'Websocket connection established on the server.'
+    client.write 'ack from the server'
+  end
+
+  def on_message(client, data)
+    puts data
+  end
+
+  def on_shutdown(client)
+    puts 'socket closing from the server'
+  end
+
+  def on_close(client)
+    puts 'websocket closed from the server'
+  end
+end
+
+class Websocket
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env['rack.upgrade?'.freeze] == :websocket
+      env['rack.upgrade'.freeze] = WebsocketController.new
+
+      return [200, {}, []]
+    end
+
+    @app.call(env)
+  end
+end
+
+use Websocket
 run Hanami.app

--- a/config.ru
+++ b/config.ru
@@ -1,39 +1,3 @@
 require './config/environment'
 
-class WebsocketController
-  def on_open(client)
-    puts 'Websocket connection established on the server.'
-    client.write 'ack from the server'
-  end
-
-  def on_message(client, data)
-    puts data
-  end
-
-  def on_shutdown(client)
-    puts 'socket closing from the server'
-  end
-
-  def on_close(client)
-    puts 'websocket closed from the server'
-  end
-end
-
-class Websocket
-  def initialize(app)
-    @app = app
-  end
-
-  def call(env)
-    if env['rack.upgrade?'.freeze] == :websocket
-      env['rack.upgrade'.freeze] = WebsocketController.new
-
-      return [200, {}, []]
-    end
-
-    @app.call(env)
-  end
-end
-
-use Websocket
 run Hanami.app

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,8 +4,11 @@ require 'hanami/model'
 require_relative '../lib/typinggame_server'
 require_relative '../apps/web/application'
 require_relative '../apps/api/application'
+require_relative '../lib/middleware/websocket/websocket_connection'
 
 Hanami.configure do
+  middleware.use WebsocketConnection
+
   mount Api::Application, at: '/api'
   mount Web::Application, at: '/'
 

--- a/lib/middleware/websocket/websocket_connection.rb
+++ b/lib/middleware/websocket/websocket_connection.rb
@@ -1,0 +1,17 @@
+require './lib/middleware/websocket/websocket_controller'
+
+class WebsocketConnection
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env['rack.upgrade?'.freeze] == :websocket
+      env['rack.upgrade'.freeze] = WebsocketController.new
+
+      return [200, {}, []]
+    end
+
+    @app.call(env)
+  end
+end

--- a/lib/middleware/websocket/websocket_controller.rb
+++ b/lib/middleware/websocket/websocket_controller.rb
@@ -1,0 +1,18 @@
+class WebsocketController
+  def on_open(client)
+    puts 'Websocket connection established on the server.'
+    client.write 'ack from the server'
+  end
+
+  def on_message(client, data)
+    puts data
+  end
+
+  def on_shutdown(client)
+    puts 'socket closing from the server'
+  end
+
+  def on_close(client)
+    puts 'websocket closed from the server'
+  end
+end


### PR DESCRIPTION
Per the help I received from the author of Iodine and Plezi.io we've decided to use the Iodine server to utilize Websockets. To make this happen we needed to author a middleware.

We now need to run our project with `bundle exec iodine` and can specify a port with the `-p 4000` flag.