### PR TITLE
Implement Client removal upon closed connection

### DIFF
--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -1,11 +1,10 @@
-require './lib/middleware/websocket/controller'
-
 module Websocket
   class Client
-    attr_reader :controller
+    attr_reader :connection_client, :client_id
 
-    def initialize
-      @controller = Controller.new
+    def initialize(connection_client: client, client_id: client_id)
+      @connection_client = connection_client
+      @client_id = client_id
     end
   end
 end

--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -1,10 +1,9 @@
 module Websocket
   class Client
-    attr_reader :connection_client, :client_id
+    attr_reader :connection_client
 
-    def initialize(connection_client: client, client_id: client_id)
+    def initialize(connection_client: client)
       @connection_client = connection_client
-      @client_id = client_id
     end
   end
 end

--- a/lib/middleware/websocket/connection.rb
+++ b/lib/middleware/websocket/connection.rb
@@ -1,15 +1,15 @@
-require './lib/middleware/websocket/client'
+require './lib/middleware/websocket/controller'
 
 module Websocket
   class Connection
     def initialize(app)
       @app = app
-      @client = Client.new
+      @controller = Controller.new
     end
 
     def call(env)
       if env['rack.upgrade?'.freeze] == :websocket
-        env['rack.upgrade'.freeze] = @client.controller
+        env['rack.upgrade'.freeze] = @controller
         return [200, {}, []]
       end
 

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -24,7 +24,10 @@ module Websocket
     end
 
     def on_close(incoming_client)
-      puts 'websocket closed from the server'
+      closing_client =
+        @clients.select { |client| client.connection_client == incoming_client }
+
+      @clients -= closing_client
     end
   end
 end

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -1,3 +1,5 @@
+require './lib/middleware/websocket/client'
+
 module Websocket
   class Controller
     attr_reader :clients
@@ -6,21 +8,22 @@ module Websocket
       @clients = []
     end
 
-    def on_open(client)
-      @clients << client
-      puts 'Websocket connection established on the server.'
-      client.write 'ack from the server'
+    def on_open(incoming_client)
+      @clients <<
+        Client.new(
+          connection_client: incoming_client, client_id: @clients.length + 1
+        )
     end
 
-    def on_message(client, data)
+    def on_message(incoming_client, data)
       puts data
     end
 
-    def on_shutdown(client)
+    def on_shutdown(incoming_client)
       puts 'socket closing from the server'
     end
 
-    def on_close(client)
+    def on_close(incoming_client)
       puts 'websocket closed from the server'
     end
   end

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -9,10 +9,7 @@ module Websocket
     end
 
     def on_open(incoming_client)
-      @clients <<
-        Client.new(
-          connection_client: incoming_client, client_id: @clients.length + 1
-        )
+      @clients << Client.new(connection_client: incoming_client)
     end
 
     def on_message(incoming_client, data)
@@ -26,7 +23,6 @@ module Websocket
     def on_close(incoming_client)
       closing_client =
         @clients.select { |client| client.connection_client == incoming_client }
-
       @clients -= closing_client
     end
   end

--- a/spec/lib/middleware/websocket/client_spec.rb
+++ b/spec/lib/middleware/websocket/client_spec.rb
@@ -1,9 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Client do
-  let(:client) { described_class.new }
-
-  it 'creates a controller' do
-    expect(client.controller).to be_kind_of(Websocket::Controller)
-  end
+  #nothing to test yet
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -1,4 +1,32 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Controller do
+  let(:incoming_client_1) { double }
+  let(:incoming_client_2) { double }
+  let (:controller) do
+    described_class.new
+  end
+
+  describe '#on_open' do
+    subject { controller.on_open(incoming_client_1) }
+
+    it 'generates a Client' do
+      expect(subject.first).to be_kind_of(Websocket::Client)
+    end
+
+    it 'appends a Client to the client list' do
+      subject
+      client = controller.clients.first
+
+      expect(client.connection_client).to eq(incoming_client_1)
+    end
+
+    it 'assigns an incremental ID to an incoming client' do
+      subject
+      controller.on_open(incoming_client_2)
+
+      expect(controller.clients[0].client_id).to eq(1)
+      expect(controller.clients[1].client_id).to eq(2)
+    end
+  end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -20,14 +20,6 @@ RSpec.describe Websocket::Controller do
 
       expect(client.connection_client).to eq(incoming_client_1)
     end
-
-    it 'assigns an incremental ID to an incoming client' do
-      subject
-      controller.on_open(incoming_client_2)
-
-      expect(controller.clients[0].client_id).to eq(1)
-      expect(controller.clients[1].client_id).to eq(2)
-    end
   end
 
   describe '#on_close' do

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -29,4 +29,19 @@ RSpec.describe Websocket::Controller do
       expect(controller.clients[1].client_id).to eq(2)
     end
   end
+
+  describe '#on_close' do
+    subject { controller.on_close(incoming_client_2) }
+
+    it 'removes the closing client from the list of clients' do
+      controller.on_open(incoming_client_1)
+      controller.on_open(incoming_client_2)
+      subject
+
+      clients = controller.clients
+
+      expect(clients.length).to eq(1)
+      expect(clients.first.connection_client).to eq(incoming_client_1)
+    end
+  end
 end


### PR DESCRIPTION
It is intuitive to interact with a single Controller object and negotiate with a list of Client objects this way, because we want each Client to have unique attributes.

We also want to be able to remove Client objects from the list that have closed their connections for obvious reasons.