### PR TITLE
Implement JSON payload generator method

### DIFF
--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -5,7 +5,10 @@ module Websocket
 
     def initialize(connection_client: client)
       @connection_client = connection_client
-      @position = '0%'
+      @position = 0
+    end
+
+    def client_attributes
       @client_attributes = { 'position' => @position }
     end
   end

--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -1,9 +1,12 @@
 module Websocket
   class Client
-    attr_reader :connection_client
+    attr_reader :connection_client, :client_attributes
+    attr_accessor :position
 
     def initialize(connection_client: client)
       @connection_client = connection_client
+      @position = '0%'
+      @client_attributes = { 'id' => @client_id, 'position' => @position }
     end
   end
 end

--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -6,7 +6,7 @@ module Websocket
     def initialize(connection_client: client)
       @connection_client = connection_client
       @position = '0%'
-      @client_attributes = { 'id' => @client_id, 'position' => @position }
+      @client_attributes = { 'position' => @position }
     end
   end
 end

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -21,9 +21,19 @@ module Websocket
     end
 
     def on_close(incoming_client)
-      closing_client =
-        @clients.select { |client| client.connection_client == incoming_client }
+      closing_client = find_client(incoming_client)
       @clients -= closing_client
+    end
+
+    def build_payload
+      players = []
+      @clients.each { |client| players << client.client_attributes }
+
+      { 'players' => players }.to_json
+    end
+
+    def find_client(incoming_client)
+      @clients.select { |client| client.connection_client == incoming_client }
     end
   end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Websocket::Controller do
       controller.on_open(incoming_client_1)
       controller.on_open(incoming_client_2)
 
-      expected_JSON = '{"players":[{"position":"0%"},{"position":"0%"}]}'
+      expected_JSON = '{"players":[{"position":0},{"position":0}]}'
 
       expect(subject).to eq(expected_JSON)
     end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -36,4 +36,29 @@ RSpec.describe Websocket::Controller do
       expect(clients.first.connection_client).to eq(incoming_client_1)
     end
   end
+
+  describe '#build_payload' do
+    subject { controller.build_payload }
+
+    it 'builds the expected payload' do
+      controller.on_open(incoming_client_1)
+      controller.on_open(incoming_client_2)
+
+      expected_JSON =
+        '{"players":[{"id":1,"position":"0%"},{"id":2,"position":"0%"}]}'
+
+      expect(subject).to eq(expected_JSON)
+    end
+  end
+
+  describe '#find_client' do
+    subject { controller.find_client(incoming_client_2) }
+
+    it 'returns the requested client' do
+      controller.on_open(incoming_client_1)
+      controller.on_open(incoming_client_2)
+
+      expect(subject.first).to eq(controller.clients[1])
+    end
+  end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe Websocket::Controller do
       controller.on_open(incoming_client_1)
       controller.on_open(incoming_client_2)
 
-      expected_JSON =
-        '{"players":[{"id":1,"position":"0%"},{"id":2,"position":"0%"}]}'
+      expected_JSON = '{"players":[{"position":"0%"},{"position":"0%"}]}'
 
       expect(subject).to eq(expected_JSON)
     end


### PR DESCRIPTION
We need to send out game state updates to all clients. We do this with
`JSON` payloads. This keeps things organized.

We also will likely need to search for clients in our `@clients` list
in multiple places, so it makes sense to pull it into its own method.

based off of #20 