### PR TITLE
Add update_all_clients method

### DIFF
--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -13,7 +13,8 @@ module Websocket
     end
 
     def on_message(incoming_client, data)
-      puts data
+      #update the Client in question
+      #update_all_clients
     end
 
     def on_shutdown(incoming_client)
@@ -34,6 +35,10 @@ module Websocket
 
     def find_client(incoming_client)
       @clients.select { |client| client.connection_client == incoming_client }
+    end
+
+    def update_all_clients
+      @clients.each { |client| client.connection_client.write(build_payload) }
     end
   end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -25,9 +25,12 @@ RSpec.describe Websocket::Controller do
   describe '#on_close' do
     subject { controller.on_close(incoming_client_2) }
 
-    it 'removes the closing client from the list of clients' do
+    before do
       controller.on_open(incoming_client_1)
       controller.on_open(incoming_client_2)
+    end
+
+    it 'removes the closing client from the list of clients' do
       subject
 
       clients = controller.clients
@@ -40,10 +43,12 @@ RSpec.describe Websocket::Controller do
   describe '#build_payload' do
     subject { controller.build_payload }
 
-    it 'builds the expected payload' do
+    before do
       controller.on_open(incoming_client_1)
       controller.on_open(incoming_client_2)
+    end
 
+    it 'builds the expected payload' do
       expected_JSON = '{"players":[{"position":0},{"position":0}]}'
 
       expect(subject).to eq(expected_JSON)
@@ -53,25 +58,27 @@ RSpec.describe Websocket::Controller do
   describe '#find_client' do
     subject { controller.find_client(incoming_client_2) }
 
-    it 'returns the requested client' do
+    before do
       controller.on_open(incoming_client_1)
       controller.on_open(incoming_client_2)
+    end
 
+    it 'returns the requested client' do
       expect(subject.first).to eq(controller.clients[1])
     end
   end
 
   describe '#update_all_clients' do
     subject { controller.update_all_clients }
-    #let(:obj) { double(:write) }
 
-    it 'calls the write method on each client' do
+    before do
       controller.on_open(incoming_client_1)
       controller.on_open(incoming_client_2)
-      payload = controller.build_payload
+    end
 
-      expect(incoming_client_1).to receive(:write).with(payload)
-      expect(incoming_client_2).to receive(:write).with(payload)
+    it 'calls the write method on each client' do
+      expect(incoming_client_1).to receive(:write)
+      expect(incoming_client_2).to receive(:write)
       subject
     end
   end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Controller do
-  let(:incoming_client_1) { double }
-  let(:incoming_client_2) { double }
+  let(:incoming_client_1) { double(write: nil) }
+  let(:incoming_client_2) { double(write: nil) }
   let (:controller) do
     described_class.new
   end
@@ -58,6 +58,21 @@ RSpec.describe Websocket::Controller do
       controller.on_open(incoming_client_2)
 
       expect(subject.first).to eq(controller.clients[1])
+    end
+  end
+
+  describe '#update_all_clients' do
+    subject { controller.update_all_clients }
+    #let(:obj) { double(:write) }
+
+    it 'calls the write method on each client' do
+      controller.on_open(incoming_client_1)
+      controller.on_open(incoming_client_2)
+      payload = controller.build_payload
+
+      expect(incoming_client_1).to receive(:write).with(payload)
+      expect(incoming_client_2).to receive(:write).with(payload)
+      subject
     end
   end
 end


### PR DESCRIPTION
When a new client is connected we need to send game state updates to all
connected clients. We can do this with a simple method. It is likely
that all of this extra code will be moved into some interactors.

Based off of #21 which is based off of #20 which is based off of master