### PR TITLE
Change all instances of client to connection

### DIFF
--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -1,10 +1,10 @@
 module Websocket
   class Client
-    attr_reader :connection_client, :client_attributes
+    attr_reader :connection, :client_attributes
     attr_accessor :position
 
-    def initialize(connection_client: client)
-      @connection_client = connection_client
+    def initialize(connection: client)
+      @connection = connection
       @position = 0
     end
 

--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -3,7 +3,7 @@ module Websocket
     attr_reader :connection, :client_attributes
     attr_accessor :position
 
-    def initialize(connection: client)
+    def initialize(connection:)
       @connection = connection
       @position = 0
     end

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -8,23 +8,23 @@ module Websocket
       @client_interactor = Interactor::ClientInteractor.new
     end
 
-    def on_open(client)
-      @client_interactor.create_client(incoming_client: client)
+    def on_open(connection)
+      @client_interactor.create_client(incoming_connection: connection)
 
       @client_interactor.update_all_clients
     end
 
-    def on_message(client, data)
+    def on_message(connection, data)
       #update the Client in question
       #update_all_clients
     end
 
-    def on_shutdown(client)
+    def on_shutdown(connection)
       puts 'socket closing from the server'
     end
 
-    def on_close(client)
-      @client_interactor.delete_client(incoming_client: client)
+    def on_close(connection)
+      @client_interactor.delete_client(incoming_connection: connection)
     end
   end
 end

--- a/lib/middleware/websocket/interactors/client_interactor.rb
+++ b/lib/middleware/websocket/interactors/client_interactor.rb
@@ -10,11 +10,11 @@ module Websocket
         @clients = []
       end
 
-      def create_client(incoming_connection: connection)
+      def create_client(incoming_connection:)
         @clients << Client.new(connection: incoming_connection)
       end
 
-      def delete_client(incoming_connection: connection)
+      def delete_client(incoming_connection:)
         @clients -= find_client(incoming_connection: incoming_connection)
       end
 
@@ -24,7 +24,7 @@ module Websocket
 
       private
 
-      def find_client(incoming_connection: connection)
+      def find_client(incoming_connection:)
         @clients.select { |client| client.connection == incoming_connection }
       end
     end

--- a/lib/middleware/websocket/interactors/client_interactor.rb
+++ b/lib/middleware/websocket/interactors/client_interactor.rb
@@ -10,12 +10,12 @@ module Websocket
         @clients = []
       end
 
-      def create_client(incoming_client: client)
-        @clients << Client.new(connection_client: incoming_client)
+      def create_client(incoming_connection: connection)
+        @clients << Client.new(connection: incoming_connection)
       end
 
-      def delete_client(incoming_client: client)
-        @clients -= find_client(incoming_client: incoming_client)
+      def delete_client(incoming_connection: connection)
+        @clients -= find_client(incoming_connection: incoming_connection)
       end
 
       def update_all_clients
@@ -24,8 +24,8 @@ module Websocket
 
       private
 
-      def find_client(incoming_client: client)
-        @clients.select { |client| client.connection_client == incoming_client }
+      def find_client(incoming_connection: connection)
+        @clients.select { |client| client.connection == incoming_connection }
       end
     end
   end

--- a/lib/middleware/websocket/interactors/update_all_clients.rb
+++ b/lib/middleware/websocket/interactors/update_all_clients.rb
@@ -5,7 +5,7 @@ module Websocket
     class UpdateAllClients
       def call(clients: clients)
         payload = generate_payload(clients: clients)
-        clients.each { |client| client.connection_client.write(payload) }
+        clients.each { |client| client.connection.write(payload) }
       end
 
       private

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Controller do
-  let(:client) { double }
+  let(:connection) { double }
   let (:controller) do
     described_class.new
   end
@@ -15,11 +15,11 @@ RSpec.describe Websocket::Controller do
   end
 
   describe '#on_open' do
-    subject { controller.on_open(client) }
+    subject { controller.on_open(connection) }
 
     it 'tells the interactor to generate a Client' do
       expect(controller.client_interactor).to receive(:create_client).with(
-        incoming_client: client
+        incoming_connection: connection
       )
       subject
     end
@@ -31,11 +31,11 @@ RSpec.describe Websocket::Controller do
   end
 
   describe '#on_close' do
-    subject { controller.on_close(client) }
+    subject { controller.on_close(connection) }
 
     it 'tells the interactor to remove the incoming client' do
       expect(controller.client_interactor).to receive(:delete_client).with(
-        incoming_client: client
+        incoming_connection: connection
       )
       subject
     end

--- a/spec/lib/middleware/websocket/interactors/build_payload_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/build_payload_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::BuildPayload do
   let(:client_1) do
-    Websocket::Client.new(connection_client: double('client').as_null_object)
+    Websocket::Client.new(connection: double('connection').as_null_object)
   end
   let(:client_2) do
-    Websocket::Client.new(connection_client: double('client').as_null_object)
+    Websocket::Client.new(connection: double('connection').as_null_object)
   end
   let(:clients) { [client_1, client_2] }
 

--- a/spec/lib/middleware/websocket/interactors/client_interactor_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/client_interactor_spec.rb
@@ -2,26 +2,30 @@ require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::ClientInteractor do
   let(:client_interactor) { described_class.new }
-  let(:client_1) { double('client').as_null_object }
-  let(:client_2) { double('client').as_null_object }
+  let(:connection_1) { double('connection').as_null_object }
+  let(:connection_2) { double('connection').as_null_object }
 
   describe '#create_client' do
-    subject { client_interactor.create_client(incoming_client: client_1) }
+    subject do
+      client_interactor.create_client(incoming_connection: connection_1)
+    end
 
     it 'appends a Client to the client list' do
       subject
       client = client_interactor.clients.first
 
-      expect(client.connection_client).to eq(client_1)
+      expect(client.connection).to eq(connection_1)
     end
   end
 
   describe '#delete_client' do
-    subject { client_interactor.delete_client(incoming_client: client_2) }
+    subject do
+      client_interactor.delete_client(incoming_connection: connection_2)
+    end
 
     before do
-      client_interactor.create_client(incoming_client: client_1)
-      client_interactor.create_client(incoming_client: client_2)
+      client_interactor.create_client(incoming_connection: connection_1)
+      client_interactor.create_client(incoming_connection: connection_2)
     end
 
     it 'removes the incoming client from the client list' do
@@ -30,21 +34,21 @@ RSpec.describe Websocket::Interactor::ClientInteractor do
       clients = client_interactor.clients
 
       expect(clients.length).to eq(1)
-      expect(clients.first.connection_client).to eq(client_1)
+      expect(clients.first.connection).to eq(connection_1)
     end
   end
 
   describe '#update_all_clients' do
     before do
-      client_interactor.create_client(incoming_client: client_1)
-      client_interactor.create_client(incoming_client: client_2)
+      client_interactor.create_client(incoming_connection: connection_1)
+      client_interactor.create_client(incoming_connection: connection_2)
     end
     subject { client_interactor.update_all_clients }
 
     it 'updates all clients using the write method' do
       client_interactor
-      expect(client_interactor.clients[0].connection_client).to receive(:write)
-      expect(client_interactor.clients[1].connection_client).to receive(:write)
+      expect(client_interactor.clients[0].connection).to receive(:write)
+      expect(client_interactor.clients[1].connection).to receive(:write)
       subject
     end
   end

--- a/spec/lib/middleware/websocket/interactors/update_all_clients_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/update_all_clients_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::UpdateAllClients do
   let(:client_1) do
-    Websocket::Client.new(connection_client: double('client').as_null_object)
+    Websocket::Client.new(connection: double('connection').as_null_object)
   end
   let(:client_2) do
-    Websocket::Client.new(connection_client: double('client').as_null_object)
+    Websocket::Client.new(connection: double('connection').as_null_object)
   end
   let(:clients) { [client_1, client_2] }
   let(:update_all_clients) { described_class.new }
@@ -15,8 +15,8 @@ RSpec.describe Websocket::Interactor::UpdateAllClients do
 
     it 'calls the write method for each client' do
       update_all_clients
-      expect(client_1.connection_client).to receive(:write)
-      expect(client_2.connection_client).to receive(:write)
+      expect(client_1.connection).to receive(:write)
+      expect(client_2.connection).to receive(:write)
       subject
     end
   end


### PR DESCRIPTION
Iodine's Connection class is the class that TCP/IP, WebSockets and SSE connections inherit from. Instances of this class are passed to the callback objects, which in our case has previously been known as a `client`.

This instance looks like this: `#<Iodine::Connection:0x00007fcb2ccbaaa8>`

This is what we see get passed into the `Controller` methods as parameters.

I would argue that this should be called a `connection` rather than a client, because we can then better represent this `connection` as an attribute to each of our `Client` objects. Calling the connection object a `client` has lead to multiple cases of confusion in the past.