### PR TITLE
Delete Player from database upon connection close

### DIFF
--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -1,4 +1,5 @@
 require './lib/typinggame_server/interactors/players/create_player'
+require './lib/typinggame_server/interactors/players/destroy_player'
 
 module Websocket
   class Client
@@ -12,6 +13,10 @@ module Websocket
 
     def generate_player
       @player = Interactors::Players::CreatePlayer.new.call.player
+    end
+
+    def delete_player
+      Interactors::Players::DestroyPlayer.new.call(@player.token)
     end
 
     def client_attributes

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -25,7 +25,11 @@ module Websocket
     end
 
     def on_close(connection)
-      @clients -= find_client(connection: connection)
+      client = find_client(connection: connection)
+      client.first.delete_player
+      @clients -= client
+
+      Interactor::UpdateAllClients.new.call(clients: @clients)
     end
 
     private

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -26,8 +26,8 @@ module Websocket
 
     def on_close(connection)
       client = find_client(connection: connection)
-      client.first.delete_player
-      @clients -= client
+      client.delete_player
+      @clients -= [client]
 
       Interactor::UpdateAllClients.new.call(clients: @clients)
     end
@@ -40,7 +40,7 @@ module Websocket
     end
 
     def find_client(connection:)
-      @clients.select { |client| client.connection == connection }
+      @clients.select { |client| client.connection == connection }.first
     end
   end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -26,17 +26,24 @@ RSpec.describe Websocket::Controller do
   end
 
   describe '#on_close' do
+    subject { controller.on_close(connection_2) }
+
     before do
       controller.on_open(connection_1)
       controller.on_open(connection_2)
-      controller.on_close(connection_2)
     end
 
     it 'removes the incoming client from the client list' do
+      subject
       clients = controller.clients
 
       expect(clients.length).to eq(1)
       expect(clients.first.connection).to eq(connection_1)
+    end
+
+    it 'updates all clients using the write method' do
+      expect(controller.clients[0].connection).to receive(:write)
+      subject
     end
   end
 end


### PR DESCRIPTION
When a Client closes its connection we need to delete the Player entity
from the database associated with that connection because we don't want
to continue rendering that Player.

We also update all clients on the race state when this happens so that
they don't mis-render the game.