### PR TITLE
Implement Room scaffolding

### DIFF
--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -3,12 +3,13 @@ require './lib/typinggame_server/interactors/players/destroy_player'
 
 module Websocket
   class Client
-    attr_reader :connection, :player
+    attr_reader :connection, :player, :room
     attr_accessor :position
 
     def initialize(connection:)
       @connection = connection
       @position = 0
+      @room = connection.env['PATH_INFO'][1..]
     end
 
     def generate_player

--- a/lib/middleware/websocket/client.rb
+++ b/lib/middleware/websocket/client.rb
@@ -3,13 +3,13 @@ require './lib/typinggame_server/interactors/players/destroy_player'
 
 module Websocket
   class Client
-    attr_reader :connection, :player, :room
-    attr_accessor :position
+    attr_reader :connection, :player
+    attr_accessor :position, :room_id
 
     def initialize(connection:)
       @connection = connection
       @position = 0
-      @room = connection.env['PATH_INFO'][1..]
+      @room_id = nil
     end
 
     def generate_player

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -1,11 +1,13 @@
 require './lib/middleware/websocket/client'
 require './lib/middleware/websocket/interactors/updates/race_update'
 require './lib/middleware/websocket/interactors/updates/client_creation_update'
+require './lib/middleware/websocket/room'
 require 'json'
 
 module Websocket
   class Controller
-    attr_reader :clients, :rooms
+    attr_reader :clients
+    attr_accessor :rooms
 
     def initialize
       @clients = []
@@ -40,19 +42,36 @@ module Websocket
     private
 
     def generate_client(connection:)
-      @clients << Client.new(connection: connection)
-      @rooms << connection.env['PATH_INFO'][1..]
-      @clients.last.generate_player
+      client = Client.new(connection: connection)
+      setup_room(client: client)
+      client.generate_player
+      @clients << client
 
       Interactor::ClientCreationUpdate.new.call(client: @clients.last)
     end
 
     def find_client(connection:)
-      @clients.select { |client| client.connection == connection }.first
+      @clients.detect { |client| client.connection == connection }
     end
 
     def race_update
       @race_update ||= Interactor::RaceUpdate.new
+    end
+
+    def setup_room(client:)
+      connection_path = client.connection.env['PATH_INFO'][1..].to_i
+
+      room = @rooms.detect { |room| room.id == connection_path }
+
+      if room.nil?
+        new_room = Room.new(id: connection_path)
+        @rooms << new_room
+        new_room.add_client(client: client)
+        client.room_id = new_room.id
+      else
+        room.add_client(client: client)
+        client.room_id = room.id
+      end
     end
   end
 end

--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -5,10 +5,11 @@ require 'json'
 
 module Websocket
   class Controller
-    attr_reader :clients
+    attr_reader :clients, :rooms
 
     def initialize
       @clients = []
+      @rooms = []
     end
 
     def on_open(connection)
@@ -40,6 +41,7 @@ module Websocket
 
     def generate_client(connection:)
       @clients << Client.new(connection: connection)
+      @rooms << connection.env['PATH_INFO'][1..]
       @clients.last.generate_player
 
       Interactor::ClientCreationUpdate.new.call(client: @clients.last)

--- a/lib/middleware/websocket/room.rb
+++ b/lib/middleware/websocket/room.rb
@@ -1,0 +1,14 @@
+module Websocket
+  class Room
+    attr_reader :id
+
+    def initialize(id:)
+      @id = id
+      @clients = []
+    end
+
+    def add_client(client:)
+      @clients << client
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/room_spec.rb
+++ b/spec/lib/middleware/websocket/room_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Room do
+  #nothing to test yet
+end


### PR DESCRIPTION
When a connection is established to the server we receive a hash that
details the HTTP Request. We can access this and save the path info to
use as a server 'room'. This will allow us to generate a URL on the
React client and associate connected clients with that room URL.

example: websocket.com/34

where 34 is the lobby ID.