### PR TITLE
Implement Rooms

### DIFF
--- a/apps/api/controllers/rooms/create.rb
+++ b/apps/api/controllers/rooms/create.rb
@@ -11,6 +11,8 @@ module Api
         end
 
         def call(_params)
+          headers['Access-Control-Allow-Origin'] = '*'
+          headers['Access-Control-Request-Method'] = '*'
           @room = @create_room.call.room
         end
       end

--- a/apps/api/controllers/rooms/show.rb
+++ b/apps/api/controllers/rooms/show.rb
@@ -11,6 +11,9 @@ module Api
         end
 
         def call(params)
+          headers['Access-Control-Allow-Origin'] = '*'
+          headers['Access-Control-Request-Method'] = '*'
+
           room = @fetch_room.call(params[:id]).room
           halt 404 if room.nil?
           @room = room

--- a/lib/middleware/websocket/interactors/handle_message.rb
+++ b/lib/middleware/websocket/interactors/handle_message.rb
@@ -4,16 +4,16 @@ require './lib/middleware/websocket/interactors/updates/timer_update'
 module Websocket
   module Interactor
     class HandleMessage
-      def call(data:, client:, clients:)
+      def call(data:, room:, client:)
         @data = data
         @client = client
-        @clients = clients
+        @room = room
 
         if data.key?('position')
           client.position = data['position']
-          Interactor::RaceUpdate.new.call(clients: @clients)
+          Interactor::RaceUpdate.new.call(room: @room)
         elsif data.key?('countdown')
-          Interactor::TimerUpdate.new.call(clients: @clients)
+          Interactor::TimerUpdate.new.call(room: @room)
         end
       end
     end

--- a/lib/middleware/websocket/interactors/updates/race_update.rb
+++ b/lib/middleware/websocket/interactors/updates/race_update.rb
@@ -3,7 +3,8 @@ require './lib/middleware/websocket/interactors/payloads/race_payload'
 module Websocket
   module Interactor
     class RaceUpdate
-      def call(clients:)
+      def call(room:)
+        clients = room.clients
         payload = generate_race_payload(clients: clients)
         clients.each { |client| client.connection.write(payload) }
       end

--- a/lib/middleware/websocket/interactors/updates/timer_update.rb
+++ b/lib/middleware/websocket/interactors/updates/timer_update.rb
@@ -3,7 +3,8 @@ require './lib/middleware/websocket/interactors/payloads/timer_payload'
 module Websocket
   module Interactor
     class TimerUpdate
-      def call(clients:)
+      def call(room:)
+        clients = room.clients
         payload = generate_timer_payload(clients: clients)
         clients.each { |client| client.connection.write(payload) }
       end

--- a/lib/middleware/websocket/room.rb
+++ b/lib/middleware/websocket/room.rb
@@ -1,6 +1,6 @@
 module Websocket
   class Room
-    attr_reader :id
+    attr_reader :id, :clients
 
     def initialize(id:)
       @id = id
@@ -9,6 +9,7 @@ module Websocket
 
     def add_client(client:)
       @clients << client
+      client.room_id = @id
     end
   end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -4,22 +4,28 @@ RSpec.describe Websocket::Controller do
   let(:env_1) { { 'PATH_INFO' => '/1' } }
   let(:env_2) { { 'PATH_INFO' => '/2' } }
   let(:connection_1) { double('connection', env: env_1).as_null_object }
-  let(:connection_2) { double('connection', env: env_2).as_null_object }
+  let(:connection_2) { double('connection', env: env_1).as_null_object }
+  let(:connection_3) { double('connection', env: env_2).as_null_object }
+  let(:connection_4) { double('connection', env: env_2).as_null_object }
   let(:controller) { described_class.new }
 
   describe '#on_open' do
     before do
       controller.on_open(connection_1)
       controller.on_open(connection_2)
+      controller.on_open(connection_3)
+      controller.on_open(connection_4)
     end
     it 'appends a Client to the client list' do
       expect(controller.clients[0].connection).to eq(connection_1)
       expect(controller.clients[1].connection).to eq(connection_2)
     end
 
-    it 'updates all clients using the write method' do
+    it 'updates the clients in the connecting clients room using the write method' do
       expect(controller.clients[0].connection).to receive(:write)
       expect(controller.clients[1].connection).to receive(:write)
+      expect(controller.clients[2].connection).not_to receive(:write)
+      expect(controller.clients[3].connection).not_to receive(:write)
 
       controller.on_open(connection_1)
       controller.on_open(connection_2)
@@ -27,34 +33,28 @@ RSpec.describe Websocket::Controller do
   end
 
   describe '#on_open room generation' do
-    context "the rooms being joined don't exist" do
-      before do
-        controller.on_open(connection_1)
-        controller.on_open(connection_2)
-      end
+    context "the room being joined doesn't exist" do
+      before { controller.on_open(connection_1) }
 
-      it 'generates new rooms' do
-        expect(controller.rooms.length).to eq(2)
+      it 'generates a new room' do
+        expect(controller.rooms.length).to eq(1)
       end
     end
 
     context 'the rooms being joined exist' do
       let(:room_1) { Websocket::Room.new(id: 1) }
-      let(:room_2) { Websocket::Room.new(id: 2) }
 
       before do
         controller.rooms << room_1
-        controller.rooms << room_2
         controller.on_open(connection_1)
         controller.on_open(connection_2)
       end
 
-      it 'adds the clients to the room' do
+      it 'adds the client to the room' do
         expect(controller.clients[0].room_id).to eq(1)
+        expect(controller.clients[1].room_id).to eq(1)
         expect(controller.rooms[0].id).to eq(1)
-
-        expect(controller.clients[1].room_id).to eq(2)
-        expect(controller.rooms[1].id).to eq(2)
+        expect(controller.rooms[0].clients.length).to eq(2)
       end
     end
   end
@@ -63,38 +63,37 @@ RSpec.describe Websocket::Controller do
     let(:data) { '{"position":33.33333333333333}' }
     subject { controller.on_message(connection_1, data) }
 
-    before { controller.on_open(connection_1) }
+    before do
+      controller.on_open(connection_1)
+      controller.on_open(connection_2)
+      controller.on_open(connection_3)
+      controller.on_open(connection_4)
+    end
 
     it 'updates the client position' do
       subject
       expect(controller.clients.first.position).to eq(33.33333333333333)
     end
 
-    it 'updates all clients with the status of the race' do
-      expect(controller.clients.first.connection).to receive(:write)
+    it 'updates the clients in the connecting clients room with the status of the race' do
+      expect(controller.clients[0].connection).to receive(:write)
+      expect(controller.clients[1].connection).to receive(:write)
+      expect(controller.clients[2].connection).not_to receive(:write)
+      expect(controller.clients[3].connection).not_to receive(:write)
       subject
     end
   end
 
   describe '#on_close' do
-    subject { controller.on_close(connection_2) }
+    subject { controller.on_close(connection_1) }
 
-    before do
-      controller.on_open(connection_1)
-      controller.on_open(connection_2)
-    end
+    before { controller.on_open(connection_1) }
 
     it 'removes the incoming client from the client list' do
       subject
       clients = controller.clients
 
-      expect(clients.length).to eq(1)
-      expect(clients.first.connection).to eq(connection_1)
-    end
-
-    it 'updates all clients using the write method' do
-      expect(controller.clients[0].connection).to receive(:write)
-      subject
+      expect(clients.length).to eq(0)
     end
   end
 end

--- a/spec/lib/middleware/websocket/interactors/handle_message_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/handle_message_spec.rb
@@ -7,16 +7,22 @@ RSpec.describe Websocket::Interactor::HandleMessage do
   let(:client_2) do
     Websocket::Client.new(connection: double('connection').as_null_object)
   end
+  let(:room) { Websocket::Room.new(id: 1) }
   let(:clients) { [client_1, client_2] }
 
   describe '#call' do
     describe 'a position update' do
       let(:data) { { 'position' => 5 } }
+
       subject do
-        described_class.new.call(data: data, client: client_1, clients: clients)
+        described_class.new.call(data: data, room: room, client: client_1)
       end
 
       before do
+        room.add_client(client: client_1)
+        room.add_client(client: client_2)
+        client_1.room_id = 1
+        client_2.room_id = 1
         allow(client_1.player).to receive(:id)
         allow(client_2.player).to receive(:id)
       end
@@ -26,7 +32,7 @@ RSpec.describe Websocket::Interactor::HandleMessage do
         expect(client_1.position).to eq(5)
       end
 
-      it('updates all clients with the race status') do
+      it('updates all clients in the clients room with the race status') do
         expect(client_1.connection).to receive(:write)
         expect(client_2.connection).to receive(:write)
         subject
@@ -36,15 +42,19 @@ RSpec.describe Websocket::Interactor::HandleMessage do
     describe 'the countdown has started' do
       let(:data) { { 'countdown' => true } }
       subject do
-        described_class.new.call(data: data, client: client_1, clients: clients)
+        described_class.new.call(data: data, room: room, client: client_1)
       end
 
       before do
+        room.add_client(client: client_1)
+        room.add_client(client: client_2)
+        client_1.room_id = 1
+        client_2.room_id = 1
         allow(client_1.player).to receive(:id)
         allow(client_2.player).to receive(:id)
       end
 
-      it 'updates all clients with the timer status' do
+      it 'updates all clients in the clients room with the timer status' do
         expect(client_1.connection).to receive(:write).with(
           '{"countdown":true}'
         )

--- a/spec/lib/middleware/websocket/interactors/updates/race_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/race_update_spec.rb
@@ -8,16 +8,21 @@ RSpec.describe Websocket::Interactor::RaceUpdate do
     Websocket::Client.new(connection: double('connection').as_null_object)
   end
   let(:clients) { [client_1, client_2] }
+  let(:room) { Websocket::Room.new(id: 1) }
 
   describe '#race_update' do
-    subject { described_class.new.call(clients: clients) }
+    subject { described_class.new.call(room: room) }
 
     before do
+      client_1.room_id = 1
+      client_2.room_id = 1
+      room.add_client(client: client_1)
+      room.add_client(client: client_2)
       allow(client_1.player).to receive(:id).and_return(1)
       allow(client_2.player).to receive(:id).and_return(2)
     end
 
-    it 'calls the write method for each client' do
+    it 'calls the write method for each client in the room' do
       expect(client_1.connection).to receive(:write)
       expect(client_2.connection).to receive(:write)
       subject

--- a/spec/lib/middleware/websocket/interactors/updates/timer_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/timer_update_spec.rb
@@ -8,16 +8,21 @@ RSpec.describe Websocket::Interactor::TimerUpdate do
     Websocket::Client.new(connection: double('connection').as_null_object)
   end
   let(:clients) { [client_1, client_2] }
+  let(:room) { Websocket::Room.new(id: 1) }
 
   describe '#call' do
-    subject { described_class.new.call(clients: clients) }
+    subject { described_class.new.call(room: room) }
 
     before do
+      client_1.room_id = 1
+      client_2.room_id = 1
+      room.add_client(client: client_1)
+      room.add_client(client: client_2)
       allow(client_1.player).to receive(:id).and_return(1)
       allow(client_2.player).to receive(:id).and_return(2)
     end
 
-    it 'calls the write method for each client' do
+    it 'calls the write method for each client in the room' do
       expect(client_1.connection).to receive(:write).with('{"countdown":true}')
       expect(client_2.connection).to receive(:write).with('{"countdown":true}')
       subject

--- a/spec/lib/middleware/websocket/room_spec.rb
+++ b/spec/lib/middleware/websocket/room_spec.rb
@@ -1,5 +1,20 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Room do
-  #nothing to test yet
+  let(:client) do
+    Websocket::Client.new(connection: double('connection').as_null_object)
+  end
+  let(:room) { described_class.new(id: 1) }
+
+  describe '#add_client' do
+    before { room.add_client(client: client) }
+
+    it 'adds the client to the rooms client list' do
+      expect(room.clients.length).to eq(1)
+    end
+
+    it 'sets the clients ID to the rooms ID' do
+      expect(client.room_id).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
When a new connection comes in we want to add it to the room that it
belongs to per the PATH INFO we receive in the request. We want to
create a new room if the room being requested doesn't exist so that we
can add all future connections for that room, to that room.

We no longer want to update the entire client list with race and timer
updates, rather we now want to update only the rooms that the messages
are associated with.