### PR TITLE
Add room and position columns to Player entity

### DIFF
--- a/db/migrations/20190625175330_create_players.rb
+++ b/db/migrations/20190625175330_create_players.rb
@@ -7,6 +7,8 @@ Hanami::Model.migration do
       column :token,
              'uuid',
              default: Hanami::Model::Sql.function(:uuid_generate_v4)
+      column :room, Integer
+      column :position, Integer
     end
   end
 


### PR DESCRIPTION
Due to concurrency we can't maintain in-memory state across all threads.
We will attempt to keep track of Player states via the database so that
we can build race payloads serverside to keep work off of the front end.

We need to figure out a way to do this because the front end will be
drastically slow on slower computers if we are maintaining state there.

It makes functional sense for React to render what our server sends it
rather than have it maintain all clients states.