### PR TITLE
Add foreign keys to link Player and Room entities

### DIFF
--- a/db/migrations/20190722235803_players_rooms.rb
+++ b/db/migrations/20190722235803_players_rooms.rb
@@ -1,0 +1,14 @@
+Hanami::Model.migration do
+  change do
+    create_table :players_rooms do
+      primary_key :id
+      foreign_key :player_id, :players
+      foreign_key :room_id, :rooms
+      column :position, Integer, null: false, default: 0
+
+      constraint(:position_constraint) { position >= 0 && position <= 100 }
+
+      index %i[player_id room_id], unique: true
+    end
+  end
+end


### PR DESCRIPTION
Due to concurrency we can't maintain in-memory state across all threads.
We will attempt to keep track of Player states via the database so that
we can build race payloads serverside to keep work off of the front end.

We need to figure out a way to do this because the front end will be
drastically slow on slower computers if we are maintaining state there.

It makes functional sense for React to render what our server sends it
rather than have it maintain all clients states itself.

By creating a Players_Rooms associative table we can ensure Players and
Rooms are unique and perform queries across the tables to filter data.