### PR TITLE
Update TimerUpdate

### DIFF
--- a/lib/middleware/websocket/interactors/updates/timer_update.rb
+++ b/lib/middleware/websocket/interactors/updates/timer_update.rb
@@ -3,16 +3,8 @@ require './lib/middleware/websocket/interactors/payloads/timer_payload'
 module Websocket
   module Interactor
     class TimerUpdate
-      def call(room:)
-        clients = room.clients
-        payload = generate_timer_payload(clients: clients)
-        clients.each { |client| client.connection.write(payload) }
-      end
-
-      private
-
-      def generate_timer_payload(clients:)
-        TimerPayload.new.call
+      def call(connection:, room_id:)
+        connection.publish "#{room_id}", "#{TimerPayload.new.call}"
       end
     end
   end

--- a/spec/lib/middleware/websocket/interactors/updates/timer_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/timer_update_spec.rb
@@ -1,30 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::TimerUpdate do
-  let(:client_1) do
-    Websocket::Client.new(connection: double('connection').as_null_object)
-  end
-  let(:client_2) do
-    Websocket::Client.new(connection: double('connection').as_null_object)
-  end
-  let(:clients) { [client_1, client_2] }
-  let(:room) { Websocket::Room.new(id: 1) }
+  let(:connection) { double('connection') }
 
   describe '#call' do
-    subject { described_class.new.call(room: room) }
+    subject { described_class.new.call(connection: connection, room_id: 5) }
 
-    before do
-      client_1.room_id = 1
-      client_2.room_id = 1
-      room.add_client(client: client_1)
-      room.add_client(client: client_2)
-      allow(client_1.player).to receive(:id).and_return(1)
-      allow(client_2.player).to receive(:id).and_return(2)
-    end
-
-    it 'calls the write method for each client in the room' do
-      expect(client_1.connection).to receive(:write).with('{"countdown":true}')
-      expect(client_2.connection).to receive(:write).with('{"countdown":true}')
+    it 'sends a countdown update to all connections of a room in a JSON payload' do
+      expect(connection).to receive(:publish).with('5', '{"countdown":true}')
       subject
     end
   end


### PR DESCRIPTION
We no longer have the concept of Client and Room objects. Therefore we
want to be able to send timer updates to all connections attached to a
given room. This is achievable with Iodine's pub/sub methods on our
connection object because it stores all connections to a room for us,
allowing us to not have to maintain connections in-memory.