### PR TITLE
Update RaceUpdate

### DIFF
--- a/lib/middleware/websocket/interactors/updates/race_update.rb
+++ b/lib/middleware/websocket/interactors/updates/race_update.rb
@@ -3,16 +3,9 @@ require './lib/middleware/websocket/interactors/payloads/race_payload'
 module Websocket
   module Interactor
     class RaceUpdate
-      def call(room:)
-        clients = room.clients
-        payload = generate_race_payload(clients: clients)
-        clients.each { |client| client.connection.write(payload) }
-      end
-
-      private
-
-      def generate_race_payload(clients:)
-        RacePayload.new.call(clients: clients)
+      def call(connection:, room_id:)
+        connection.publish "#{room_id}",
+                           "#{RacePayload.new.call(room_id: room_id)}"
       end
     end
   end

--- a/spec/lib/middleware/websocket/interactors/updates/race_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/race_update_spec.rb
@@ -1,30 +1,29 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::RaceUpdate do
-  let(:client_1) do
-    Websocket::Client.new(connection: double('connection').as_null_object)
-  end
-  let(:client_2) do
-    Websocket::Client.new(connection: double('connection').as_null_object)
-  end
-  let(:clients) { [client_1, client_2] }
-  let(:room) { Websocket::Room.new(id: 1) }
+  let(:connection) { double('connection') }
+  let(:player_1) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:player_2) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
+  let(:create_player_room) { Interactors::PlayersRooms::CreatePlayersRooms.new }
 
-  describe '#race_update' do
-    subject { described_class.new.call(room: room) }
-
-    before do
-      client_1.room_id = 1
-      client_2.room_id = 1
-      room.add_client(client: client_1)
-      room.add_client(client: client_2)
-      allow(client_1.player).to receive(:id).and_return(1)
-      allow(client_2.player).to receive(:id).and_return(2)
+  describe '#call' do
+    subject do
+      described_class.new.call(connection: connection, room_id: room.id)
     end
 
-    it 'calls the write method for each client in the room' do
-      expect(client_1.connection).to receive(:write)
-      expect(client_2.connection).to receive(:write)
+    before do
+      create_player_room.call(player_id: player_1.id, room_id: room.id)
+      create_player_room.call(player_id: player_2.id, room_id: room.id)
+    end
+
+    it 'publishes a race payload to the specified room' do
+      expect(connection).to receive(:publish).with(
+        "#{room.id}",
+        "{\"players\":[{\"id\":#{player_1.id},\"position\":0},{\"id\":#{
+          player_2.id
+        },\"position\":0}]}"
+      )
       subject
     end
   end


### PR DESCRIPTION
We no longer have the concept of Client and Room objects. Therefore we
need to be able to send race updates to all connections attached to a
given room. This is achievable with Iodine's pub/sub methods on our
connection object because it stores all connections to a room for us,
allowing us to not have to maintain connections in-memory.