### PR TITLE
Implement HandleNewConnection service object

### DIFF
--- a/lib/middleware/websocket/interactors/handle_new_connection.rb
+++ b/lib/middleware/websocket/interactors/handle_new_connection.rb
@@ -1,0 +1,47 @@
+require './lib/middleware/websocket/interactors/updates/player_creation_update'
+require './lib/middleware/websocket/interactors/updates/race_update'
+require './lib/typinggame_server/interactors/players/create_player'
+require './lib/typinggame_server/interactors/rooms/fetch_room'
+require './lib/typinggame_server/interactors/players_rooms/create_players_rooms'
+
+module Websocket
+  module Interactor
+    class HandleNewConnection
+      def call(connection:)
+        player = create_player
+        room = find_room(id: connection.env['PATH_INFO'][1..].to_i)
+        connection.subscribe "#{room.id}"
+
+        build_association(player_id: player.id, room_id: room.id)
+
+        perform_updates(
+          connection: connection, player_id: player.id, room_id: room.id
+        )
+      end
+
+      private
+
+      def create_player
+        Interactors::Players::CreatePlayer.new.call.player
+      end
+
+      def find_room(id:)
+        Interactors::Rooms::FetchRoom.new.call(id).room
+      end
+
+      def build_association(player_id:, room_id:)
+        Interactors::PlayersRooms::CreatePlayersRooms.new.call(
+          player_id: player_id, room_id: room_id
+        )
+      end
+
+      def perform_updates(connection:, player_id:, room_id:)
+        PlayerCreationUpdate.new.call(
+          connection: connection, player_id: player_id
+        )
+
+        RaceUpdate.new.call(connection: connection, room_id: room_id)
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/handle_new_connection_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/handle_new_connection_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe Websocket::Interactor::HandleNewConnection do
+  let(:player) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
+  let(:create_players_rooms) do
+    Interactors::PlayersRooms::CreatePlayersRooms.new
+  end
+  let(:env) { { 'PATH_INFO' => "/#{room.id}" } }
+  let(:connection) { double('connection', env: env) }
+  let(:handle_new_connection) { described_class.new }
+
+  describe '#call' do
+    subject { handle_new_connection.call(connection: connection) }
+
+    before { create_players_rooms.call(player_id: player.id, room_id: room.id) }
+
+    it 'subscribes a new connection to a room' do
+      allow(connection).to receive(:publish)
+      allow(connection).to receive(:write)
+
+      expect(connection).to receive(:subscribe).with("#{room.id}")
+      subject
+    end
+
+    it 'builds an association between the player and the room' do
+      allow(connection).to receive(:publish)
+      allow(connection).to receive(:write)
+      allow(connection).to receive(:subscribe)
+
+      subject
+
+      room_information =
+        Interactors::PlayersRooms::FetchPlayersRooms.new.call(room_id: room.id)
+          .room_information
+      expect(room_information.length).to eq(2)
+      expect(room_information[0].room_id).to eq(room.id)
+    end
+
+    it 'performs a player creation update' do
+      allow(connection).to receive(:subscribe)
+      allow(connection).to receive(:publish)
+
+      expect(connection).to receive(:write).with("{\"id\":#{player.id + 1}}")
+      subject
+    end
+
+    it 'performs a race update' do
+      allow(connection).to receive(:write)
+      allow(connection).to receive(:subscribe)
+
+      expect(connection).to receive(:publish).with(
+        "#{room.id}",
+        "{\"players\":[{\"id\":#{player.id},\"position\":0},{\"id\":#{
+          player.id + 1
+        },\"position\":0}]}"
+      )
+      subject
+    end
+  end
+end


### PR DESCRIPTION
We no longer have the concept of Client and Room objects. By using
Iodine's pub/sub implementation we can avoid concurrency issues and
subscribe new connections to the room provided in the env hash from the
request.

Because Room entity's are created before a Player entity is generated
for a given connection, we find the room that was created and build an
associaton between the new Player entity and the Room. This allows us
to perform operations like race updates to all players in a room or
add new players to a room etc.

When a new connection comes in we need to let it know what its ID is
for all future updates it is to send and receive. Once this is done we
also need to send the latest race update to all players in the room
that the new connection has joined so that all clients can render the
most up to date race.