### PR TITLE
Implement HandleMessage service object

### DIFF
--- a/lib/middleware/websocket/interactors/handle_message.rb
+++ b/lib/middleware/websocket/interactors/handle_message.rb
@@ -1,20 +1,27 @@
 require './lib/middleware/websocket/interactors/updates/race_update'
 require './lib/middleware/websocket/interactors/updates/timer_update'
+require './lib/typinggame_server/interactors/players_rooms/update_players_rooms'
 
 module Websocket
   module Interactor
     class HandleMessage
-      def call(data:, room:, client:)
-        @data = data
-        @client = client
-        @room = room
+      def call(data:, connection:)
+        room_id = connection.env['PATH_INFO'][1..].to_i
 
         if data.key?('position')
-          client.position = data['position']
-          Interactor::RaceUpdate.new.call(room: @room)
+          update_player_position(data: data, room_id: room_id)
+          RaceUpdate.new.call(connection: connection, room_id: room_id)
         elsif data.key?('countdown')
-          Interactor::TimerUpdate.new.call(room: @room)
+          TimerUpdate.new.call(connection: connection, room_id: room_id)
         end
+      end
+
+      private
+
+      def update_player_position(data:, room_id:)
+        Interactors::PlayersRooms::UpdatePlayersRooms.new.call(
+          data: data, room_id: room_id
+        )
       end
     end
   end


### PR DESCRIPTION
We no longer have the concept of Client and Room objects. By using
Iodine's pub/sub implementation we can avoid concurrency issues and
send updates to specific rooms that connections have subscribed to
upon connecting.

At the moment we only have two kinds of messages to worry about. When
we receive a race update we need to alert every player in the associated
room that a players position has changed so that they can render the
most up to date race. Because we have set up a players_rooms association
table in the database we can update a given player's position there.

When we receive a timer update we also need to alert every player in
the associated room that the game has been started so that they can
also start their race timers to stay in sync.