### PR TITLE
Update controller

### DIFF
--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -1,31 +1,16 @@
-require './lib/middleware/websocket/client'
-require './lib/middleware/websocket/interactors/updates/race_update'
-require './lib/middleware/websocket/interactors/updates/client_creation_update'
-require './lib/middleware/websocket/room'
+require './lib/middleware/websocket/interactors/handle_new_connection'
+require './lib/middleware/websocket/interactors/handle_message'
 require 'json'
 
 module Websocket
   class Controller
-    attr_reader :clients
-    attr_accessor :rooms
-
-    def initialize
-      @clients = []
-      @rooms = []
-    end
-
     def on_open(connection)
-      client = generate_client(connection: connection)
-
-      race_update.call(room: find_room(id: client.room_id))
+      Interactor::HandleNewConnection.new.call(connection: connection)
     end
 
     def on_message(connection, data)
-      client = find_client(connection: connection)
-      room = find_room(id: client.room_id)
-
       Interactor::HandleMessage.new.call(
-        data: JSON.parse(data), room: room, client: client
+        data: JSON.parse(data), connection: connection
       )
     end
 
@@ -34,50 +19,9 @@ module Websocket
     end
 
     def on_close(connection)
-      client = find_client(connection: connection)
-      client.delete_player
-      @clients -= [client]
-
-      race_update.call(room: find_room(id: client.room_id))
-    end
-
-    private
-
-    def generate_client(connection:)
-      client = Client.new(connection: connection)
-      client.generate_player
-      @clients << client
-      setup_room(client: client)
-
-      Interactor::ClientCreationUpdate.new.call(client: @clients.last)
-
-      return client
-    end
-
-    def setup_room(client:)
-      connection_path = client.connection.env['PATH_INFO'][1..].to_i
-      room = find_room(id: connection_path)
-
-      if room.nil?
-        room = Room.new(id: connection_path)
-        @rooms << room
-      end
-
-      room.add_client(client: client)
-
-      return room
-    end
-
-    def find_client(connection:)
-      @clients.detect { |client| client.connection == connection }
-    end
-
-    def race_update
-      @race_update ||= Interactor::RaceUpdate.new
-    end
-
-    def find_room(id:)
-      @rooms.detect { |room| room.id == id }
+      #find the Player and delete them
+      #find the associated table entry and delete it
+      #check if the room is empty - if yes, delete it
     end
   end
 end

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -1,99 +1,49 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Controller do
-  let(:env_1) { { 'PATH_INFO' => '/1' } }
-  let(:env_2) { { 'PATH_INFO' => '/2' } }
-  let(:connection_1) { double('connection', env: env_1).as_null_object }
-  let(:connection_2) { double('connection', env: env_1).as_null_object }
-  let(:connection_3) { double('connection', env: env_2).as_null_object }
-  let(:connection_4) { double('connection', env: env_2).as_null_object }
-  let(:controller) { described_class.new }
-
-  describe '#on_open' do
-    before do
-      controller.on_open(connection_1)
-      controller.on_open(connection_2)
-      controller.on_open(connection_3)
-      controller.on_open(connection_4)
-    end
-    it 'appends a Client to the client list' do
-      expect(controller.clients[0].connection).to eq(connection_1)
-      expect(controller.clients[1].connection).to eq(connection_2)
-    end
-
-    it 'updates the clients in the connecting clients room using the write method' do
-      expect(controller.clients[0].connection).to receive(:write)
-      expect(controller.clients[1].connection).to receive(:write)
-      expect(controller.clients[2].connection).not_to receive(:write)
-      expect(controller.clients[3].connection).not_to receive(:write)
-
-      controller.on_open(connection_1)
-      controller.on_open(connection_2)
-    end
+  let(:player) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
+  let(:env) { { 'PATH_INFO' => "/#{room.id}" } }
+  let(:connection) { double('connection', env: env) }
+  let(:create_players_rooms) do
+    Interactors::PlayersRooms::CreatePlayersRooms.new
   end
 
-  describe '#on_open room generation' do
-    context "the room being joined doesn't exist" do
-      before { controller.on_open(connection_1) }
+  describe '#on_open' do
+    subject { described_class.new.on_open(connection) }
 
-      it 'generates a new room' do
-        expect(controller.rooms.length).to eq(1)
-      end
-    end
+    it 'handles the new connection' do
+      expect(connection).to receive(:subscribe)
+      expect(connection).to receive(:publish)
+      expect(connection).to receive(:write)
 
-    context 'the rooms being joined exist' do
-      let(:room_1) { Websocket::Room.new(id: 1) }
-
-      before do
-        controller.rooms << room_1
-        controller.on_open(connection_1)
-        controller.on_open(connection_2)
-      end
-
-      it 'adds the client to the room' do
-        expect(controller.clients[0].room_id).to eq(1)
-        expect(controller.clients[1].room_id).to eq(1)
-        expect(controller.rooms[0].id).to eq(1)
-        expect(controller.rooms[0].clients.length).to eq(2)
-      end
+      subject
     end
   end
 
   describe '#on_message' do
-    let(:data) { '{"position":33.33333333333333}' }
-    subject { controller.on_message(connection_1, data) }
+    before { create_players_rooms.call(player_id: player.id, room_id: room.id) }
 
-    before do
-      controller.on_open(connection_1)
-      controller.on_open(connection_2)
-      controller.on_open(connection_3)
-      controller.on_open(connection_4)
+    context 'race update' do
+      let(:data) { { 'id' => player.id, 'position' => 30 }.to_json }
+
+      subject { described_class.new.on_message(connection, data) }
+
+      it 'handles the message' do
+        expect(connection).to receive(:publish)
+        subject
+      end
     end
 
-    it 'updates the client position' do
-      subject
-      expect(controller.clients.first.position).to eq(33.33333333333333)
-    end
+    context 'countdown update' do
+      let(:data) { { 'countdown' => true }.to_json }
 
-    it 'updates the clients in the connecting clients room with the status of the race' do
-      expect(controller.clients[0].connection).to receive(:write)
-      expect(controller.clients[1].connection).to receive(:write)
-      expect(controller.clients[2].connection).not_to receive(:write)
-      expect(controller.clients[3].connection).not_to receive(:write)
-      subject
-    end
-  end
+      subject { described_class.new.on_message(connection, data) }
 
-  describe '#on_close' do
-    subject { controller.on_close(connection_1) }
-
-    before { controller.on_open(connection_1) }
-
-    it 'removes the incoming client from the client list' do
-      subject
-      clients = controller.clients
-
-      expect(clients.length).to eq(0)
+      it 'handles the message' do
+        expect(connection).to receive(:publish)
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
We no longer have the concept of Client and Room objects. By using
Iodine's pub/sub implementation we can avoid concurrency issues and
subscribe new connections to the room provided in the env hash from the
request.

Because of this we can also send updates to specific rooms that
connections have subscribed to upon connecting.