### PR TITLE
Fix require 'spec_helper' inconsistencies in specs

### DIFF
--- a/spec/api/controllers/players/create_spec.rb
+++ b/spec/api/controllers/players/create_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe Api::Controllers::Players::Create, type: :action do
   let(:repository) { PlayerRepository.new }
   let(:create_player) do

--- a/spec/api/controllers/rooms/create_spec.rb
+++ b/spec/api/controllers/rooms/create_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe Api::Controllers::Rooms::Create, type: :action do
   let(:repository) { RoomRepository.new }
   let(:create_room) do

--- a/spec/lib/typinggame_server/repositories/players_repository_spec.rb
+++ b/spec/lib/typinggame_server/repositories/players_repository_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe PlayerRepository, type: :repository do
   let(:repository) { PlayerRepository.new }
   let(:uuid) { SecureRandom.uuid }


### PR DESCRIPTION
Some specs did not have require 'spec_helper'. This would become
apparent when we decide to run specs individually that require things
in spec_helper.