### PR TITLE
Fix RSpec.describe inconsistencies in specs

### DIFF
--- a/spec/lib/typinggame_server/interactors/players/create_player_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players/create_player_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Players::CreatePlayer do
+RSpec.describe Interactors::Players::CreatePlayer do
   let(:repository) { PlayerRepository.new }
   let(:create_player) { described_class.new(repository: repository) }
   let(:result) { create_player.call }

--- a/spec/lib/typinggame_server/interactors/players/destroy_player_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players/destroy_player_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'securerandom'
 
-describe Interactors::Players::DestroyPlayer do
+RSpec.describe Interactors::Players::DestroyPlayer do
   let(:repository) { PlayerRepository.new }
   let(:destroy_player) { described_class.new(repository: repository) }
   let(:uuid) { SecureRandom.uuid }

--- a/spec/lib/typinggame_server/interactors/players/fetch_all_players_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players/fetch_all_players_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Players::FetchAllPlayers do
+RSpec.describe Interactors::Players::FetchAllPlayers do
   let(:repository) { PlayerRepository.new }
   let(:fetch_all_players) { described_class.new(repository: repository) }
 

--- a/spec/lib/typinggame_server/interactors/players/fetch_player_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players/fetch_player_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Players::FetchPlayer do
+RSpec.describe Interactors::Players::FetchPlayer do
   let(:repository) { PlayerRepository.new }
   let(:fetch_player) { described_class.new(repository: repository) }
   let(:params) { 1 }

--- a/spec/lib/typinggame_server/interactors/rooms/create_room_spec.rb
+++ b/spec/lib/typinggame_server/interactors/rooms/create_room_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Rooms::CreateRoom do
+RSpec.describe Interactors::Rooms::CreateRoom do
   let(:repository) { RoomRepository.new }
   let(:create_room) { described_class.new(repository: repository) }
   let(:result) { create_room.call }

--- a/spec/lib/typinggame_server/interactors/rooms/destroy_room_spec.rb
+++ b/spec/lib/typinggame_server/interactors/rooms/destroy_room_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Rooms::DestroyRoom do
+RSpec.describe Interactors::Rooms::DestroyRoom do
   let(:repository) { RoomRepository.new }
   let(:destroy_room) { described_class.new(repository: repository) }
 

--- a/spec/lib/typinggame_server/interactors/rooms/fetch_all_rooms_spec.rb
+++ b/spec/lib/typinggame_server/interactors/rooms/fetch_all_rooms_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Rooms::FetchAllRooms do
+RSpec.describe Interactors::Rooms::FetchAllRooms do
   let(:repository) { RoomRepository.new }
   let(:fetch_all_rooms) { described_class.new(repository: repository) }
 

--- a/spec/lib/typinggame_server/interactors/rooms/fetch_room_spec.rb
+++ b/spec/lib/typinggame_server/interactors/rooms/fetch_room_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactors::Rooms::FetchRoom do
+RSpec.describe Interactors::Rooms::FetchRoom do
   let(:repository) { RoomRepository.new }
   let(:fetch_room) { described_class.new(repository: repository) }
   let(:params) { 1 }


### PR DESCRIPTION
Not including RSpec before the class describe is an old style.

As of Rpec 3 you can disable the global availability of describe by
limiting the DSL.

Prefixing with Rspec.describe ensures tests will still run after
implementing the limitation.