### PR TITLE
Add rack-cors dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'prettier'
 gem 'pry'
 gem 'iodine'
 gem 'faraday'
+gem 'rack-cors'
 
 gem 'pg'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.1.1)
     rack (2.0.7)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
@@ -214,6 +215,7 @@ DEPENDENCIES
   pg
   prettier
   pry
+  rack-cors
   rake
   rspec
   rubocop

--- a/apps/api/controllers/rooms/create.rb
+++ b/apps/api/controllers/rooms/create.rb
@@ -11,8 +11,6 @@ module Api
         end
 
         def call(_params)
-          headers['Access-Control-Allow-Origin'] = '*'
-          headers['Access-Control-Request-Method'] = '*'
           @room = @create_room.call.room
         end
       end

--- a/apps/api/controllers/rooms/show.rb
+++ b/apps/api/controllers/rooms/show.rb
@@ -11,9 +11,6 @@ module Api
         end
 
         def call(params)
-          headers['Access-Control-Allow-Origin'] = '*'
-          headers['Access-Control-Request-Method'] = '*'
-
           room = @fetch_room.call(params[:id]).room
           halt 404 if room.nil?
           @room = room

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,6 +7,13 @@ require_relative '../apps/api/application'
 require_relative '../lib/middleware/websocket/connection'
 
 Hanami.configure do
+  middleware.use Rack::Cors do
+    allow do
+      origins '*'
+      resource '*', headers: :any, methods: %i[get post options]
+    end
+  end
+
   middleware.use Websocket::Connection
 
   mount Api::Application, at: '/api'


### PR DESCRIPTION
CORS has been a headache to deal with over Hanami as there is no way to globally declare that cross origin resource sharing is allowed.

During development this will help us avoid headaches making requests as we are dealing with everything locally and there is no security issue. Once we move to production we will be able to whitelist the URL that our client will be making requests from such that it will be the only application capable of making requests to our server cross origin.