### PR TITLE
Add .env.development to .gitignore

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,0 @@
-# Define ENV variables for development environment
-DATABASE_URL="postgresql://localhost/typinggame_dev"
-SERVE_STATIC_ASSETS="true"
-WEB_SESSIONS_SECRET="f9d54ed946de025dd802a2675ffa04096a851366b539ceb916e34a3063b24957"
-API_SESSIONS_SECRET="ee5feef037aaea27f8964e4f07ee25905fb8cf11e985ecf5d1d52d0c83b27ab4"

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,0 @@
-# Define ENV variables for test environment
-DATABASE_URL="postgresql://localhost/typinggame_test"
-SERVE_STATIC_ASSETS="true"
-WEB_SESSIONS_SECRET="82a0f3d9b949a9d12a8bd182133cde1bb2f586fe06dd2aee04eb12380474229b"
-API_SESSIONS_SECRET="ac4370093f7a061afb5ef2da6f8c94fb6b87a23ce8c9207d2e5b7cabcc95a921"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /public/assets*
 /tmp
+.env.development

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /public/assets*
 /tmp
 .env.development
+.env.test


### PR DESCRIPTION
We will be implementing OAuth with Slack that will involve storing
secret information in the development ENV file. To avoid publicizing
this information on GitHub we won't allow it to be uploaded.

Moving forward we will have to reset all keys currently stored in
.env.development when we move to production as they've been in this
repo for a while and that's probably not a good thing.