### PR TITLE
Add UUID column to user migration

### DIFF
--- a/db/migrations/20190731163609_create_users.rb
+++ b/db/migrations/20190731163609_create_users.rb
@@ -1,0 +1,7 @@
+Hanami::Model.migration do
+  change do
+    alter_table :users do
+      column :uuid, default: Hanami::Model::Sql.function(:uuid_generate_v4)
+    end
+  end
+end


### PR DESCRIPTION
Upon authentication with Slack we need to verify that all future
updates via websockets happen from an authenticated source. This
halts attempts at modifying values in the browser to render components
and possibly send game updates without authentication.

We could use the access_token from Slack in the browser to perform
validation checks but this would likely end up in session storage, which
would possibly allow someone to figure out someone elses access_token.

By using a UUID and an updated_at column in the user table we can set
session limits on UUID's such that we don't accept requests after X
amount of minutes, thus expiring UUIDs. The UUID is unique, but also
not an identifying attribute given to us by a third party, such as an
access_token from Slack.