### PR TITLE
Revert "Add UUID column to user migration"

### DIFF
--- a/db/migrations/20190731163609_create_users.rb
+++ b/db/migrations/20190731163609_create_users.rb
@@ -1,7 +1,0 @@
-Hanami::Model.migration do
-  change do
-    alter_table :users do
-      column :uuid, default: Hanami::Model::Sql.function(:uuid_generate_v4)
-    end
-  end
-end

--- a/db/migrations/20190731163609_create_users.rb
+++ b/db/migrations/20190731163609_create_users.rb
@@ -1,0 +1,7 @@
+Hanami::Model.migration do
+  change do
+    alter_table :users do
+      add_column :uuid, default: Hanami::Model::Sql.function(:uuid_generate_v4)
+    end
+  end
+end


### PR DESCRIPTION
Reverts daelynj/typinggame-server#58

This migration is incorrect.

`add_column` is the correct syntax when performing an `alter_table`.