### PR TITLE
Generate migration to make Players represent Users

### DIFF
--- a/db/migrations/20190731195957_create_players.rb
+++ b/db/migrations/20190731195957_create_players.rb
@@ -1,0 +1,17 @@
+Hanami::Model.migration do
+  change do
+    alter_table :players do
+      add_column :created_at, DateTime, null: false
+      add_column :updated_at, DateTime, null: false
+
+      add_column :user_id, String, null: false, unique: true
+      add_column :name, String, null: false
+      add_column :team_id, String, null: false
+      add_column :access_token, String, null: false, unique: true
+
+      rename_column :token, :uuid
+    end
+
+    drop_table :users
+  end
+end


### PR DESCRIPTION
Since we already have foreign keys in the players_rooms table that link
the players table we can avoid messing with that and just move what we
need into the players table and have the players table be our concept
of users.