### PR TITLE
Update FetchPlayer to fetch by uuid or access token

### DIFF
--- a/lib/typinggame_server/interactors/players/fetch_player.rb
+++ b/lib/typinggame_server/interactors/players/fetch_player.rb
@@ -8,11 +8,16 @@ module Interactors
       expose :player
 
       def initialize(repository: PlayerRepository.new)
-        @players_repository = repository
+        @player_repository = repository
       end
 
-      def call(params)
-        @player = @players_repository.find(params)
+      def call(access_token: nil, uuid: nil)
+        if uuid.nil?
+          @player =
+            @player_repository.find_by_access_token(access_token: access_token)
+        elsif access_token.nil?
+          @player = @player_repository.find_by_uuid(uuid: uuid)
+        end
       end
     end
   end

--- a/spec/lib/typinggame_server/interactors/players/fetch_player_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players/fetch_player_spec.rb
@@ -2,23 +2,48 @@ require 'spec_helper'
 
 RSpec.describe Interactors::Players::FetchPlayer do
   let(:repository) { PlayerRepository.new }
-  let(:fetch_player) { described_class.new(repository: repository) }
-  let(:params) { 1 }
-
-  before do
-    repository.create(id: '1')
-    repository.create(id: '2')
+  let(:player) do
+    repository.create(
+      player_id: '1',
+      name: 'octane',
+      team_id: 'X0klA3',
+      access_token: 'fdgdfg908g9n9gf09fgh8'
+    )
   end
+  let(:fetch_player) { described_class.new(repository: repository) }
 
-  context 'When the player exists' do
-    let(:result) { fetch_player.call(params) }
+  describe '#call' do
+    context 'when given an access token' do
+      let(:result) { fetch_player.call(access_token: 'fdgdfd408g9n9de30agh8') }
 
-    it 'succeeds' do
-      expect(result.successful?).to be(true)
+      before do
+        repository.create(
+          player_id: '2',
+          name: 'dominus',
+          team_id: 'X0MlR3',
+          access_token: 'fdgdfd408g9n9de30agh8'
+        )
+      end
+
+      it 'succeeds' do
+        expect(result.successful?).to be(true)
+      end
+
+      it 'fetches a player by access token' do
+        expect(result.player.player_id).to eq('2')
+      end
     end
 
-    it 'fetches a player by id' do
-      expect(result.player.id).to eq(1)
+    context 'when given a UUID' do
+      let(:result) { fetch_player.call(uuid: player.uuid) }
+
+      it 'succeeds' do
+        expect(result.successful?).to be(true)
+      end
+
+      it 'fetches a player by UUID' do
+        expect(result.player.player_id).to eq('1')
+      end
     end
   end
 end


### PR DESCRIPTION
Due to the changes we've made to the Player entity we need to be able
to fetch by UUID or access token. We separate this fetch into an
interactor to remove business logic from wherever we would be
performing this interaction.