### PR TITLE
Implement Slack OAuth endpoint

### DIFF
--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -3,11 +3,8 @@
 #
 # Example:
 # get '/hello', to: ->(env) { [200, {}, ['Hello from Hanami!']] }
-get '/players', to: 'players#index'
-get '/players/:id', to: 'players#show'
-delete '/players', to: 'players#destroy'
-post '/players', to: 'players#create'
 get '/rooms', to: 'rooms#index'
 post '/rooms', to: 'rooms#create'
 delete '/rooms/:id', to: 'rooms#destroy'
 get '/rooms/:id', to: 'rooms#show'
+post '/slack/oauth', to: 'slack#oauth'

--- a/apps/api/controllers/slack/oauth.rb
+++ b/apps/api/controllers/slack/oauth.rb
@@ -1,0 +1,29 @@
+module Api
+  module Controllers
+    module Slack
+      class Oauth
+        include Api::Action
+
+        expose :uuid
+        expose :authenticated
+
+        def initialize(interactor: Interactors::Slack::FetchOauth.new)
+          @oauth_interactor = interactor
+        end
+
+        def call(params)
+          code = params[:code]
+          redirect_uri = params[:redirectURI]
+
+          halt 400 && self.status = 400 if code.nil?
+
+          response =
+            @oauth_interactor.call(code: code, redirect_uri: redirect_uri)
+
+          @uuid = response.uuid
+          @authenticated = response.authenticated
+        end
+      end
+    end
+  end
+end

--- a/apps/api/views/slack/oauth.rb
+++ b/apps/api/views/slack/oauth.rb
@@ -1,0 +1,17 @@
+module Api
+  module Views
+    module Slack
+      class Oauth
+        include Api::View
+
+        def render
+          if authenticated
+            raw JSON.generate({ authenticated: authenticated, uuid: uuid })
+          else
+            raw JSON.generate({ authenticated: authenticated })
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/typinggame_server/interactors/slack/fetch_identity.rb
+++ b/lib/typinggame_server/interactors/slack/fetch_identity.rb
@@ -1,0 +1,40 @@
+require 'hanami/interactor'
+require 'faraday'
+
+module Interactors
+  module Slack
+    class FetchIdentity
+      include Hanami::Interactor
+
+      expose :uuid
+      expose :authenticated
+
+      def initialize(connection:)
+        @connection = connection
+      end
+
+      def call(access_token:)
+        identity_response =
+          @connection.get '/api/users.identity', { token: access_token }
+
+        body = JSON.parse(identity_response.env['body'])
+
+        create_player(body: body, access_token: access_token) if body['ok']
+      end
+
+      private
+
+      def create_player(body:, access_token:)
+        player =
+          Players::CreatePlayer.new.call(
+            player_attributes: body['user'],
+            team: body['team'],
+            access_token: access_token
+          )
+            .player
+        @authenticated = body['ok']
+        @uuid = player.uuid
+      end
+    end
+  end
+end

--- a/lib/typinggame_server/interactors/slack/fetch_oauth.rb
+++ b/lib/typinggame_server/interactors/slack/fetch_oauth.rb
@@ -1,0 +1,70 @@
+require 'hanami/interactor'
+require 'faraday'
+
+module Interactors
+  module Slack
+    class FetchOauth
+      include Hanami::Interactor
+
+      expose :uuid
+      expose :authenticated
+
+      def initialize
+        @connection =
+          Faraday.new(url: 'https://slack.com') do |faraday|
+            faraday.request :url_encoded
+            faraday.response :logger
+            faraday.adapter Faraday.default_adapter
+          end
+      end
+
+      def call(code:, redirect_uri:)
+        oauth_response =
+          @connection.post '/api/oauth.access',
+                           {
+                             client_id: ENV.fetch('CLIENT_ID'),
+                             client_secret: ENV.fetch('CLIENT_SECRET'),
+                             code: code,
+                             redirect_uri: redirect_uri
+                           }
+
+        body = JSON.parse(oauth_response.env['body'])
+
+        return if player_exists?(access_token: body['access_token'])
+
+        if body['ok']
+          build_player_identity(access_token: body['access_token'])
+        else
+          @authenticated = false
+        end
+      end
+
+      private
+
+      def player_exists?(access_token:)
+        player =
+          Players::FetchPlayer.new.call(access_token: access_token).player
+
+        player.nil? ? false : update_player(player: player)
+      end
+
+      def update_player(player:)
+        updated_player =
+          Players::UpdatePlayer.new.call(player: player).updated_player
+
+        @authenticated = true
+        @uuid = updated_player.uuid
+      end
+
+      def build_player_identity(access_token:)
+        response =
+          FetchIdentity.new(connection: @connection).call(
+            access_token: access_token
+          )
+
+        @uuid = response.uuid
+        @authenticated = response.authenticated
+      end
+    end
+  end
+end

--- a/spec/api/controllers/slack/oauth_spec.rb
+++ b/spec/api/controllers/slack/oauth_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Api::Controllers::Slack::Oauth, type: :action do
+end

--- a/spec/api/views/slack/oauth_spec.rb
+++ b/spec/api/views/slack/oauth_spec.rb
@@ -1,0 +1,2 @@
+RSpec.describe Api::Views::Slack::Oauth, type: :view do
+end

--- a/spec/lib/typinggame_server/interactors/slack/fetch_identity_spec.rb
+++ b/spec/lib/typinggame_server/interactors/slack/fetch_identity_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+RSpec.describe Interactors::Slack::FetchIdentity do
+end

--- a/spec/lib/typinggame_server/interactors/slack/fetch_oauth_spec.rb
+++ b/spec/lib/typinggame_server/interactors/slack/fetch_oauth_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+RSpec.describe Interactors::Slack::FetchOauth do
+end


### PR DESCRIPTION
We needed a way to authenticate players in our game so that we can persist Player entities in our database. To do this we authenticate with Slack, giving us the ability to whitelist the JUUL Labs Slack workspace in the end. This also allows us to make secure updates based on an expiring UUID that we will give the client.

I will have to learn how the VCR gem works so that I can write specs for this PR at some point.