### PR TITLE
Implement UpdatePlayer interactor

### DIFF
--- a/lib/typinggame_server/interactors/players/update_player.rb
+++ b/lib/typinggame_server/interactors/players/update_player.rb
@@ -1,0 +1,21 @@
+require 'hanami/interactor'
+require 'securerandom'
+
+module Interactors
+  module Players
+    class UpdatePlayer
+      include Hanami::Interactor
+
+      expose :updated_player
+
+      def initialize(repository: PlayerRepository.new)
+        @player_repository = repository
+      end
+
+      def call(player:)
+        @updated_player =
+          @player_repository.update(player.id, uuid: SecureRandom.uuid)
+      end
+    end
+  end
+end

--- a/spec/lib/typinggame_server/interactors/players/update_player_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players/update_player_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Interactors::Players::UpdatePlayer do
+  let(:repository) { PlayerRepository.new }
+  let(:player) do
+    repository.create(
+      player_id: '1',
+      name: 'octane',
+      team_id: 'X0klA3',
+      access_token: 'fdgdfg908g9n9gf09fgh8'
+    )
+  end
+  let(:update_player) { described_class.new(repository: repository) }
+
+  describe '#call' do
+    let(:result) { update_player.call(player: player) }
+
+    it 'succeeds' do
+      expect(result.successful?).to be(true)
+    end
+
+    it 'updates a players UUID' do
+      expect(result.updated_player.uuid).not_to eq(player.uuid)
+    end
+  end
+end


### PR DESCRIPTION
When a person goes to play the game they will require a new UUID upon
being authenticated if they want to be able to perform game updates.

We will implement a way for UUIDs to expire, but for now every time a
user is authenticated they will be given a new one.