### PR TITLE
Update RaceUpdate spec for Player entity changes

### DIFF
--- a/spec/lib/middleware/websocket/interactors/updates/race_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/race_update_spec.rb
@@ -2,8 +2,29 @@ require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::RaceUpdate do
   let(:connection) { double('connection') }
-  let(:player_1) { Interactors::Players::CreatePlayer.new.call.player }
-  let(:player_2) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:player_attributes_1) { { 'id' => 1, 'name' => 'octane' } }
+  let(:team_1) { { 'id' => 'X0klA3' } }
+  let(:access_token_1) { 'fdgdfg908g9n9gf09fgh8' }
+  let(:player_attributes_2) { { 'id' => 2, 'name' => 'dominus' } }
+  let(:team_2) { { 'id' => 'Ie034K' } }
+  let(:access_token_2) { 'fdasdgsfgfng9gf09fghg' }
+
+  let(:player_1) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes_1,
+      team: team_1,
+      access_token: access_token_1
+    )
+      .player
+  end
+  let(:player_2) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes_2,
+      team: team_2,
+      access_token: access_token_2
+    )
+      .player
+  end
   let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
   let(:create_player_room_record) do
     Interactors::PlayersRooms::CreatePlayerRoom.new
@@ -22,9 +43,11 @@ RSpec.describe Websocket::Interactor::RaceUpdate do
     it 'publishes a race payload to the specified room' do
       expect(connection).to receive(:publish).with(
         "#{room.id}",
-        "{\"players\":[{\"id\":#{player_1.id},\"position\":0},{\"id\":#{
+        "{\"players\":[{\"id\":#{
+          player_1.id
+        },\"name\":\"octane\",\"position\":0},{\"id\":#{
           player_2.id
-        },\"position\":0}]}"
+        },\"name\":\"dominus\",\"position\":0}]}"
       )
       subject
     end


### PR DESCRIPTION
We have changed the way that we generte Player entities and also now
pass along names to the client. The spec needs to reflect these changes.