### PR TITLE
Update HandleNewConnection service object

### DIFF
--- a/lib/middleware/websocket/interactors/handle_new_connection.rb
+++ b/lib/middleware/websocket/interactors/handle_new_connection.rb
@@ -1,46 +1,64 @@
-require './lib/middleware/websocket/interactors/updates/player_creation_update'
+require './lib/middleware/websocket/interactors/updates/player_join_update'
 require './lib/middleware/websocket/interactors/updates/race_update'
-require './lib/typinggame_server/interactors/players/create_player'
+require './lib/typinggame_server/interactors/players/fetch_player'
 require './lib/typinggame_server/interactors/rooms/fetch_room'
 require './lib/typinggame_server/interactors/players_rooms/create_player_room'
+require './lib/typinggame_server/interactors/players_rooms/fetch_player_room'
 
 module Websocket
   module Interactor
     class HandleNewConnection
-      def call(connection:)
-        player = create_player
-        room = find_room(id: connection.env['PATH_INFO'][1..].to_i)
+      def call(uuid:, connection:)
+        player = fetch_player(uuid: uuid)
+        room = fetch_room(id: connection.env['PATH_INFO'][1..].to_i)
         connection.subscribe "#{room.id}"
 
         build_association(player_id: player.id, room_id: room.id)
 
         perform_updates(
-          connection: connection, player_id: player.id, room_id: room.id
+          connection: connection,
+          player_name: player.name,
+          player_id: player.id,
+          room_id: room.id
         )
       end
 
       private
 
-      def create_player
-        Interactors::Players::CreatePlayer.new.call.player
+      def fetch_player(uuid:)
+        Interactors::Players::FetchPlayer.new.call(uuid: uuid).player
       end
 
-      def find_room(id:)
+      def fetch_room(id:)
         Interactors::Rooms::FetchRoom.new.call(id).room
       end
 
       def build_association(player_id:, room_id:)
-        Interactors::PlayersRooms::CreatePlayerRoom.new.call(
-          player_id: player_id, room_id: room_id
-        )
+        return if association_exists?(player_id: player_id, room_id: room_id)
+
+        player_room_record =
+          Interactors::PlayersRooms::CreatePlayerRoom.new.call(
+            player_id: player_id, room_id: room_id
+          )
+            .player_room_record
       end
 
-      def perform_updates(connection:, player_id:, room_id:)
-        PlayerCreationUpdate.new.call(
-          connection: connection, player_id: player_id
+      def perform_updates(connection:, player_name:, player_id:, room_id:)
+        PlayerJoinUpdate.new.call(
+          connection: connection, player_name: player_name, player_id: player_id
         )
 
         RaceUpdate.new.call(connection: connection, room_id: room_id)
+      end
+
+      def association_exists?(player_id:, room_id:)
+        player_room_record =
+          Interactors::PlayersRooms::FetchPlayerRoom.new.call(
+            player_id: player_id, room_id: room_id
+          )
+            .player_room_record
+
+        player_room_record.nil? ? false : true
       end
     end
   end


### PR DESCRIPTION
We do a lot of things differently now when it comes to adding new
players. We no longer generate Player entities here as we have started
to persist them through OAuth.

We require a UUID to perform updates so we need to verify that a request
is authorized.