### PR TITLE
Update HandleMessage service object

### DIFF
--- a/lib/middleware/websocket/interactors/handle_message.rb
+++ b/lib/middleware/websocket/interactors/handle_message.rb
@@ -1,18 +1,31 @@
 require './lib/middleware/websocket/interactors/updates/race_update'
 require './lib/middleware/websocket/interactors/updates/timer_update'
+require './lib/middleware/websocket/interactors/handle_new_connection'
 require './lib/typinggame_server/interactors/players_rooms/update_player_room'
+require './lib/typinggame_server/interactors/players/fetch_player'
 
 module Websocket
   module Interactor
     class HandleMessage
       def call(data:, connection:)
         room_id = connection.env['PATH_INFO'][1..].to_i
+        uuid = data['uuid']
 
-        if data.key?('position')
-          update_player_position(data: data, room_id: room_id)
-          RaceUpdate.new.call(connection: connection, room_id: room_id)
-        elsif data.key?('countdown')
-          TimerUpdate.new.call(connection: connection, room_id: room_id)
+        if uuid && data.length == 1
+          Interactor::HandleNewConnection.new.call(
+            uuid: uuid, connection: connection
+          )
+        end
+
+        if data.key?('position') && data.key?('uuid')
+          if player_verified?(uuid: uuid)
+            update_player_position(data: data, room_id: room_id)
+            RaceUpdate.new.call(connection: connection, room_id: room_id)
+          end
+        elsif data.key?('countdown') && data.key?('uuid')
+          if player_verified?(uuid: uuid)
+            TimerUpdate.new.call(connection: connection, room_id: room_id)
+          end
         end
       end
 
@@ -22,6 +35,12 @@ module Websocket
         Interactors::PlayersRooms::UpdatePlayerRoom.new.call(
           data: data, room_id: room_id
         )
+      end
+
+      def player_verified?(uuid:)
+        player = Interactors::Players::FetchPlayer.new.call(uuid: uuid).player
+
+        player.nil? ? false : true
       end
     end
   end

--- a/spec/lib/middleware/websocket/interactors/handle_message_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/handle_message_spec.rb
@@ -1,7 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Interactor::HandleMessage do
-  let(:player) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:player_attributes) { { 'id' => 1, 'name' => 'octane' } }
+  let(:team) { { 'id' => 'X0klA3' } }
+  let(:access_token) { 'fdgdfg908g9n9gf09fgh8' }
+  let(:player) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes,
+      team: team,
+      access_token: access_token
+    )
+      .player
+  end
   let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
   let(:env) { { 'PATH_INFO' => "/#{room.id}" } }
   let(:connection) { double('connection', env: env) }
@@ -15,8 +25,34 @@ RSpec.describe Websocket::Interactor::HandleMessage do
       create_player_room_record.call(player_id: player.id, room_id: room.id)
     end
 
-    context 'when the client sends a position update' do
-      let(:data) { { 'id' => player.id, 'position' => 30 } }
+    context 'when the client sends their uuid' do
+      let(:data) { { 'uuid' => player.uuid } }
+      subject { handle_message.call(data: data, connection: connection) }
+
+      it 'subscribes the player to a room, and performs player join and race updates' do
+        expect(connection).to receive(:subscribe).with("#{room.id}")
+        expect(connection).to receive(:write).with(
+          "{\"id\":#{player.id},\"name\":\"octane\"}"
+        )
+        expect(connection).to receive(:publish).with(
+          "#{room.id}",
+          "{\"players\":[{\"id\":#{
+            player.id
+          },\"name\":\"octane\",\"position\":0}]}"
+        )
+        subject
+      end
+    end
+
+    context 'when the client sends a position update with a proper UUID' do
+      let(:data) do
+        {
+          'id' => player.id,
+          'uuid' => player.uuid,
+          'name' => 'octane',
+          'position' => 30
+        }
+      end
       subject { handle_message.call(data: data, connection: connection) }
 
       it 'updates the players position' do
@@ -36,15 +72,34 @@ RSpec.describe Websocket::Interactor::HandleMessage do
       it 'sends all players in the room a race update' do
         expect(connection).to receive(:publish).with(
           "#{room.id}",
-          "{\"players\":[{\"id\":#{player.id},\"position\":30}]}"
+          "{\"players\":[{\"id\":#{
+            player.id
+          },\"name\":\"octane\",\"position\":30}]}"
         )
 
         subject
       end
     end
 
+    context 'when the client sends a position update with an improper UUID' do
+      let(:data) do
+        {
+          'id' => player.id,
+          'uuid' => 'improper uuid',
+          'name' => 'octane',
+          'position' => 30
+        }
+      end
+
+      subject { handle_message.call(data: data, connection: connection) }
+
+      it 'fails to perform the update' do
+        expect(subject).to be(nil)
+      end
+    end
+
     context 'when a player sends a countdown update' do
-      let(:data) { { 'countdown' => true } }
+      let(:data) { { 'uuid' => player.uuid, 'countdown' => true } }
 
       subject { handle_message.call(data: data, connection: connection) }
 


### PR DESCRIPTION
We now require that all requests be verified through a UUID. Moving
forward we will implement a time check for expired UUIDs.

We perform all of the same updates as before, but now check that a
requests UUID is valid so that we are only performing valid race
updates.