### PR TITLE
Update Controller service object

### DIFF
--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -1,11 +1,10 @@
-require './lib/middleware/websocket/interactors/handle_new_connection'
 require './lib/middleware/websocket/interactors/handle_message'
 require 'json'
 
 module Websocket
   class Controller
     def on_open(connection)
-      Interactor::HandleNewConnection.new.call(connection: connection)
+      #do nothing, we don't know you yet
     end
 
     def on_message(connection, data)

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -1,7 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe Websocket::Controller do
-  let(:player) { Interactors::Players::CreatePlayer.new.call.player }
+  let(:player_attributes) { { 'id' => 1, 'name' => 'octane' } }
+  let(:team) { { 'id' => 'X0klA3' } }
+  let(:access_token) { 'fdgdfg908g9n9gf09fgh8' }
+  let(:player) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes,
+      team: team,
+      access_token: access_token
+    )
+      .player
+  end
   let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
   let(:env) { { 'PATH_INFO' => "/#{room.id}" } }
   let(:connection) { double('connection', env: env) }
@@ -9,25 +19,35 @@ RSpec.describe Websocket::Controller do
     Interactors::PlayersRooms::CreatePlayerRoom.new
   end
 
-  describe '#on_open' do
-    subject { described_class.new.on_open(connection) }
-
-    it 'handles the new connection' do
-      expect(connection).to receive(:subscribe)
-      expect(connection).to receive(:publish)
-      expect(connection).to receive(:write)
-
-      subject
-    end
-  end
-
   describe '#on_message' do
     before do
       create_player_room_record.call(player_id: player.id, room_id: room.id)
     end
 
+    context 'joining player' do
+      let(:data) { { 'uuid' => player.uuid }.to_json }
+
+      subject { described_class.new.on_message(connection, data) }
+
+      it 'handles the joining the player' do
+        expect(connection).to receive(:subscribe).with(room.id.to_s)
+        expect(connection).to receive(:write).with(
+          "{\"id\":#{player.id},\"name\":\"octane\"}"
+        )
+        expect(connection).to receive(:publish).with(
+          "#{room.id}",
+          "{\"players\":[{\"id\":#{
+            player.id
+          },\"name\":\"octane\",\"position\":0}]}"
+        )
+        subject
+      end
+    end
+
     context 'race update' do
-      let(:data) { { 'id' => player.id, 'position' => 30 }.to_json }
+      let(:data) do
+        { 'uuid' => player.uuid, 'id' => player.id, 'position' => 30 }.to_json
+      end
 
       subject { described_class.new.on_message(connection, data) }
 
@@ -38,7 +58,7 @@ RSpec.describe Websocket::Controller do
     end
 
     context 'countdown update' do
-      let(:data) { { 'countdown' => true }.to_json }
+      let(:data) { { 'uuid' => player.uuid, 'countdown' => true }.to_json }
 
       subject { described_class.new.on_message(connection, data) }
 


### PR DESCRIPTION
We no longer want to perform anything on_open because we don't know if
the opened websocket is secure without a UUID. To verify this we have
the client send us a UUID to initiate the 'handle_new_connection' flow.