### PR TITLE
Add VCR Ruby gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'pry'
 gem 'iodine'
 gem 'faraday'
 gem 'rack-cors'
+gem 'vcr'
 
 gem 'pg'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
     unicode-display_width (1.6.0)
     url_mount (0.2.1)
       rack
+    vcr (5.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -220,6 +221,7 @@ DEPENDENCIES
   rspec
   rubocop
   shotgun
+  vcr
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
We need a way to mock our requests to the Slack API. VCR supports
Faraday, the gem that we are using to make these requests.

With this gem we will be able to mock responses from the Slack API once
and not make any subsequent requests. We will also be able to use VCR to
redact sensitive information from our specs that we need for testing but
don't want to be present in the github repository.