### PR TITLE
Use .map instead of .each for race payload

### DIFF
--- a/lib/middleware/websocket/interactors/payloads/race_payload.rb
+++ b/lib/middleware/websocket/interactors/payloads/race_payload.rb
@@ -7,16 +7,14 @@ module Websocket
         players_names_positions =
           fetch_players_names_positions(room_id: room_id)
 
-        players = []
-
-        players_names_positions.each do |player|
-          players <<
+        players =
+          players_names_positions.map do |player|
             {
               'id' => player[:player_id],
               'name' => player[:name],
               'position' => player[:position]
             }
-        end
+          end
 
         { 'players' => players }.to_json
       end


### PR DESCRIPTION
A small change that helps readability and better follows the Ruby way
of doing things. This doesn't change functionality, thus all specs pass.