### PR TITLE
Implement Models for client-server communication

### DIFF
--- a/lib/middleware/websocket/interactors/models/countdown_state.rb
+++ b/lib/middleware/websocket/interactors/models/countdown_state.rb
@@ -1,0 +1,18 @@
+module Websocket
+  module Interactor
+    module Model
+      class CountdownState
+        attr_reader :type, :countdown_state
+
+        def initialize(countdown_state:)
+          @type = 'countdown'
+          @countdown_state = countdown_state
+        end
+
+        def to_json
+          { type: @type, countdown: @countdown_state }.to_json
+        end
+      end
+    end
+  end
+end

--- a/lib/middleware/websocket/interactors/models/join_state.rb
+++ b/lib/middleware/websocket/interactors/models/join_state.rb
@@ -1,0 +1,19 @@
+module Websocket
+  module Interactor
+    module Model
+      class JoinState
+        attr_reader :type, :id, :name
+
+        def initialize(id:, name:)
+          @type = 'join'
+          @id = id
+          @name = name
+        end
+
+        def to_json
+          { type: @type, id: @id, name: @name }.to_json
+        end
+      end
+    end
+  end
+end

--- a/lib/middleware/websocket/interactors/models/race_state.rb
+++ b/lib/middleware/websocket/interactors/models/race_state.rb
@@ -1,0 +1,18 @@
+module Websocket
+  module Interactor
+    module Model
+      class RaceState
+        attr_reader :type, :players
+
+        def initialize(players:)
+          @type = 'position'
+          @players = players
+        end
+
+        def to_json
+          { type: @type, players: @players }.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/models/countdown_state_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/models/countdown_state_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::Model::CountdownState do
+  let(:countdown_state_payload) { described_class.new(countdown_state: true) }
+
+  describe '.to_json' do
+    subject { countdown_state_payload.to_json }
+
+    it 'builds a json payload' do
+      expect(subject).to eq('{"type":"countdown","countdown":true}')
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/models/join_state_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/models/join_state_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::Model::JoinState do
+  let(:join_state_payload) { described_class.new(id: 1, name: 'octane') }
+
+  describe '.to_json' do
+    subject { join_state_payload.to_json }
+
+    it 'builds a json payload' do
+      expect(subject).to eq('{"type":"join","id":1,"name":"octane"}')
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/models/race_state_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/models/race_state_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::Model::RaceState do
+  let(:players) do
+    [
+      { id: 1, name: 'octane', position: 5 },
+      { id: 2, name: 'dominus', position: 20 }
+    ]
+  end
+  let(:race_state_payload) { described_class.new(players: players) }
+
+  describe '.to_json' do
+    subject { race_state_payload.to_json }
+
+    it 'builds a json payload' do
+      expect(subject).to eq(
+        '{"type":"position","players":[{"id":1,"name":"octane","position":5},{"id":2,"name":"dominus","position":20}]}'
+      )
+    end
+  end
+end


### PR DESCRIPTION
By moving to a Model interface we can better distinguish between payload types moving forward as more are needed without clogging up service objects with if statements. This will also provide clarity on the client-side as well.

Further implementation might split the JSON serialization into a separate service as the type to send is an API related concern that the model doesn’t need to know about.