### PR TITLE
Update HandleMessage to use Update Models

### DIFF
--- a/lib/typinggame_server/interactors/players_rooms/update_player_room.rb
+++ b/lib/typinggame_server/interactors/players_rooms/update_player_room.rb
@@ -11,16 +11,16 @@ module Interactors
         @player_room_repository = repository
       end
 
-      def call(data:, room_id:)
+      def call(player_id:, position:, room_id:)
         player_room_record =
           @player_room_repository.find_player_room_records(
-            player_id: data['id'], room_id: room_id
+            player_id: player_id, room_id: room_id
           )
 
         @updated_player_room_record =
           @player_room_repository.update(
             player_room_record.id,
-            position: data['position']
+            position: position
           )
       end
     end

--- a/spec/lib/typinggame_server/interactors/players_rooms/update_player_room_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players_rooms/update_player_room_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Interactors::PlayersRooms::UpdatePlayerRoom do
       .player
   end
   let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
-  let(:data) { { 'id' => player.id, 'position' => 30 } }
   let(:repository) { PlayerRoomRepository.new }
   let(:create_player_room_record) do
     Interactors::PlayersRooms::CreatePlayerRoom.new
@@ -23,7 +22,11 @@ RSpec.describe Interactors::PlayersRooms::UpdatePlayerRoom do
   end
 
   context 'when the player and room exist' do
-    subject { update_player_room_record.call(data: data, room_id: room.id) }
+    subject do
+      update_player_room_record.call(
+        player_id: player.id, position: 30, room_id: room.id
+      )
+    end
 
     before do
       create_player_room_record.call(player_id: player.id, room_id: room.id)


### PR DESCRIPTION
We now handle the Update Model generated off of the clients message.

HandleUpdate makes more sense as a class name in our current context as
we are handling Update Models we have parsed from an update from the
client.

We will now move forward to use our state models as well in the next
iteration.