### PR TITLE
Update Controller to use BuildUpdateModel

### DIFF
--- a/lib/middleware/websocket/controller.rb
+++ b/lib/middleware/websocket/controller.rb
@@ -1,4 +1,5 @@
-require './lib/middleware/websocket/interactors/handle_message'
+require './lib/middleware/websocket/interactors/handle_update'
+require './lib/middleware/websocket/interactors/build_update_model'
 require 'json'
 
 module Websocket
@@ -7,9 +8,14 @@ module Websocket
       #do nothing, we don't know you yet
     end
 
-    def on_message(connection, data)
-      Interactor::HandleMessage.new.call(
-        data: JSON.parse(data), connection: connection
+    def on_message(connection, update)
+      update_model =
+        Interactor::BuildUpdateModel.new.call(
+          update: JSON.parse(update), connection: connection
+        )
+
+      Interactor::HandleUpdate.new.call(
+        update_model: update_model, connection: connection
       )
     end
 

--- a/lib/middleware/websocket/interactors/build_update_model.rb
+++ b/lib/middleware/websocket/interactors/build_update_model.rb
@@ -8,19 +8,19 @@ module Websocket
       InvalidType = Class.new(StandardError)
 
       def call(update:, connection:)
-        case update.fetch(:type)
+        case update.fetch('type')
         when 'join'
-          Model::JoinUpdate.new(uuid: update[:uuid])
+          Model::JoinUpdate.new(uuid: update['uuid'])
         when 'position'
           Model::RaceUpdate.new(
-            id: update[:id],
-            uuid: update[:uuid],
-            name: update[:name],
-            position: update[:position]
+            id: update['id'],
+            uuid: update['uuid'],
+            name: update['name'],
+            position: update['position']
           )
         when 'countdown'
           Model::CountdownUpdate.new(
-            uuid: update[:uuid], countdown_state: update[:countdown]
+            uuid: update['uuid'], countdown_state: update['countdown']
           )
         else
           raise InvalidType

--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Websocket::Controller do
     end
 
     context 'joining player' do
-      let(:data) { { 'type' => 'join', 'uuid' => player.uuid }.to_json }
+      let(:data) { { type: 'join', uuid: player.uuid }.to_json }
 
       subject { described_class.new.on_message(connection, data) }
 
@@ -47,10 +47,7 @@ RSpec.describe Websocket::Controller do
     context 'race update' do
       let(:data) do
         {
-          'type' => 'position',
-          'uuid' => player.uuid,
-          'id' => player.id,
-          'position' => 30
+          type: 'position', uuid: player.uuid, id: player.id, position: 30
         }.to_json
       end
 
@@ -64,9 +61,7 @@ RSpec.describe Websocket::Controller do
 
     context 'countdown update' do
       let(:data) do
-        {
-          'type' => 'countdown', 'uuid' => player.uuid, 'countdown' => true
-        }.to_json
+        { type: 'countdown', uuid: player.uuid, countdown: true }.to_json
       end
 
       subject { described_class.new.on_message(connection, data) }

--- a/spec/lib/middleware/websocket/interactors/build_update_model_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/build_update_model_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Websocket::Interactor::BuildUpdateModel do
     context 'a position update' do
       let(:update) do
         {
-          type: 'position',
-          id: 1,
-          uuid: '6a380919-ef98-48c5-8461-12bc5790f2e6',
-          name: 'octane',
-          position: 30
+          'type' => 'position',
+          'id' => 1,
+          'uuid' => '6a380919-ef98-48c5-8461-12bc5790f2e6',
+          'name' => 'octane',
+          'position' => 30
         }
       end
 
@@ -26,7 +26,7 @@ RSpec.describe Websocket::Interactor::BuildUpdateModel do
 
     context 'a join update' do
       let(:update) do
-        { type: 'join', uuid: '6a380919-ef98-48c5-8461-12bc5790f2e6' }
+        { 'type' => 'join', 'uuid' => '6a380919-ef98-48c5-8461-12bc5790f2e6' }
       end
 
       subject do
@@ -39,9 +39,9 @@ RSpec.describe Websocket::Interactor::BuildUpdateModel do
     context 'a countdown update' do
       let(:update) do
         {
-          type: 'countdown',
-          uuid: '6a380919-ef98-48c5-8461-12bc5790f2e6',
-          countdown: true
+          'type' => 'countdown',
+          'uuid' => '6a380919-ef98-48c5-8461-12bc5790f2e6',
+          'countdown' => true
         }
       end
 


### PR DESCRIPTION
We can now use our BuildUpdateModel service to turn the data we've
received from the client into an entity. JSON.parse() does not use the
new Ruby syntax for Hash's so we need to modify the spec for
BuildUpdateModel after realizing this when the Controller specs failed.