### PR TITLE
Separate UUID verification into separate service

### DIFF
--- a/lib/middleware/websocket/interactors/verify_player.rb
+++ b/lib/middleware/websocket/interactors/verify_player.rb
@@ -1,0 +1,13 @@
+require './lib/typinggame_server/interactors/players/fetch_player'
+
+module Websocket
+  module Interactor
+    class VerifyPlayer
+      def call(uuid:)
+        player = Interactors::Players::FetchPlayer.new.call(uuid: uuid).player
+
+        !player.nil?
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/verify_player_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/verify_player_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::VerifyPlayer do
+  let(:player_attributes) { { 'id' => 1, 'name' => 'octane' } }
+  let(:team) { { 'id' => 'X0klA3' } }
+  let(:access_token) { 'fdgdfg908g9n9gf09fgh8' }
+  let(:player) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes,
+      team: team,
+      access_token: access_token
+    )
+      .player
+  end
+
+  describe '#call' do
+    context 'player is verified' do
+      subject { described_class.new.call(uuid: player.uuid) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'player is not verified' do
+      subject { described_class.new.call(uuid: 'bad-uuid') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
We can abstract some code from the locations where we need to verify a
player by UUID. Moving forward this will help us re-use this service.