### PR TITLE
Utilize Handlers in HandleUpdate

### DIFF
--- a/spec/lib/middleware/websocket/controller_spec.rb
+++ b/spec/lib/middleware/websocket/controller_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe Websocket::Controller do
       it 'handles the joining the player' do
         expect(connection).to receive(:subscribe).with(room.id.to_s)
         expect(connection).to receive(:write).with(
-          "{\"id\":#{player.id},\"name\":\"octane\"}"
+          "{\"type\":\"join\",\"id\":#{player.id},\"name\":\"octane\"}"
         )
         expect(connection).to receive(:publish).with(
           "#{room.id}",
-          "{\"players\":[{\"id\":#{
+          "{\"type\":\"position\",\"players\":[{\"id\":#{
             player.id
           },\"name\":\"octane\",\"position\":0}]}"
         )

--- a/spec/lib/middleware/websocket/interactors/handle_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/handle_update_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe Websocket::Interactor::HandleUpdate do
       it 'subscribes the player to a room, and performs player join and race updates' do
         expect(connection).to receive(:subscribe).with("#{room.id}")
         expect(connection).to receive(:write).with(
-          "{\"id\":#{player.id},\"name\":\"octane\"}"
+          "{\"type\":\"join\",\"id\":#{player.id},\"name\":\"octane\"}"
         )
         expect(connection).to receive(:publish).with(
           "#{room.id}",
-          "{\"players\":[{\"id\":#{
+          "{\"type\":\"position\",\"players\":[{\"id\":#{
             player.id
           },\"name\":\"octane\",\"position\":0}]}"
         )
@@ -75,7 +75,7 @@ RSpec.describe Websocket::Interactor::HandleUpdate do
       it 'sends all players in the room a race update' do
         expect(connection).to receive(:publish).with(
           "#{room.id}",
-          "{\"players\":[{\"id\":#{
+          "{\"type\":\"position\",\"players\":[{\"id\":#{
             player.id
           },\"name\":\"octane\",\"position\":30}]}"
         )
@@ -115,7 +115,7 @@ RSpec.describe Websocket::Interactor::HandleUpdate do
       it 'sends all players in the room a countdown update' do
         expect(connection).to receive(:publish).with(
           "#{room.id}",
-          '{"countdown":true}'
+          '{"type":"countdown","countdown":true}'
         )
 
         subject


### PR DESCRIPTION
We can simplify the HandleUpdate service by utilizing our Handlers.
This moves a lot of logic that didn't need to all be happening in one
place to different services where the responsibilities are quarantined.

We also finally utilize our entities created off of messages sent from
the client.