### PR TITLE
migration for player_rooms table for game stats

### DIFF
--- a/db/migrations/20190808175418_create_player_rooms.rb
+++ b/db/migrations/20190808175418_create_player_rooms.rb
@@ -6,8 +6,7 @@ Hanami::Model.migration do
       add_column :words_typed, Integer
       add_column :time, Integer
       add_column :mistakes, Integer
-      add_column :accuracy, Integer
-      add_column :wpm, Integer
+      add_column :letters_typed, Integer
     end
   end
 end

--- a/db/migrations/20190808175418_create_player_rooms.rb
+++ b/db/migrations/20190808175418_create_player_rooms.rb
@@ -1,0 +1,13 @@
+Hanami::Model.migration do
+  change do
+    alter_table :player_rooms do
+      add_column :created_at, DateTime, null: false
+      add_column :updated_at, DateTime, null: false
+      add_column :words_typed, Integer
+      add_column :time, Integer
+      add_column :mistakes, Integer
+      add_column :accuracy, Integer
+      add_column :wpm, Integer
+    end
+  end
+end


### PR DESCRIPTION
We wil use the player_rooms records as game history, and we will also
use it to record game stats that we can pass to clients as players
finish, so we can dynamically render stats.