### PR TITLE
Add stats table join for player_room repository

### DIFF
--- a/lib/typinggame_server/repositories/player_room_repository.rb
+++ b/lib/typinggame_server/repositories/player_room_repository.rb
@@ -16,4 +16,14 @@ class PlayerRoomRepository < Hanami::Repository
       .map
       .to_a
   end
+
+  def find_players_names_stats(room_id:)
+    player_rooms.read(
+      "SELECT players.name, player_rooms.player_id, player_rooms.words_typed, player_rooms.time, player_rooms.mistakes, player_rooms.letters_typed FROM player_rooms JOIN players ON players.id = player_rooms.player_id WHERE room_id = #{
+        room_id
+      } AND player_rooms.words_typed IS NOT NULL"
+    )
+      .map
+      .to_a
+  end
 end

--- a/spec/lib/typinggame_server/repositories/player_room_repository_spec.rb
+++ b/spec/lib/typinggame_server/repositories/player_room_repository_spec.rb
@@ -82,4 +82,50 @@ RSpec.describe PlayerRoomRepository, type: :repository do
       )
     end
   end
+
+  describe '#find_players_names_stats' do
+    subject { repository.find_players_names_stats(room_id: room.id) }
+
+    before do
+      repository.create(
+        player_id: player_1.id,
+        words_typed: 10,
+        time: 4,
+        mistakes: 2,
+        letters_typed: 50,
+        room_id: room.id
+      )
+      repository.create(
+        player_id: player_2.id,
+        words_typed: 10,
+        time: 6,
+        mistakes: 1,
+        letters_typed: 50,
+        room_id: room.id
+      )
+    end
+
+    it 'joins the players table and player_rooms table' do
+      expect(subject).to eq(
+        [
+          {
+            letters_typed: 50,
+            mistakes: 2,
+            name: 'octane',
+            player_id: player_1.id,
+            time: 4,
+            words_typed: 10
+          },
+          {
+            letters_typed: 50,
+            mistakes: 1,
+            name: 'dominus',
+            player_id: player_2.id,
+            time: 6,
+            words_typed: 10
+          }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
When we decide to send players' stats to the client(s) we need a way to
retrieve the name from the players table as well as retrieve information
from the player_rooms table. This allows us to compile that information
together.