### PR TITLE
Implement StatsState Model

### DIFF
--- a/lib/middleware/websocket/interactors/models/states/stats_state.rb
+++ b/lib/middleware/websocket/interactors/models/states/stats_state.rb
@@ -1,0 +1,18 @@
+module Websocket
+  module Interactor
+    module Model
+      class StatsState
+        attr_reader :type, :players
+
+        def initialize(players:)
+          @type = 'stats'
+          @players = players
+        end
+
+        def to_json
+          { type: @type, players: @players }.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/models/states/stats_state_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/models/states/stats_state_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::Model::StatsState do
+  let(:players) do
+    [
+      {
+        id: 1,
+        name: 'octane',
+        words_typed: 20,
+        time: 10,
+        mistakes: 2,
+        accuracy: 98.0,
+        wpm: 120
+      },
+      {
+        id: 2,
+        name: 'dominus',
+        words_typed: 20,
+        time: 14,
+        mistakes: 5,
+        accuracy: 95.0,
+        wpm: 86
+      }
+    ]
+  end
+  let(:stats_state_payload) { described_class.new(players: players) }
+
+  describe '.to_json' do
+    subject { stats_state_payload.to_json }
+
+    it 'builds a json payload' do
+      expect(subject).to eq(
+        '{"type":"stats","players":[{"id":1,"name":"octane","words_typed":20,"time":10,"mistakes":2,"accuracy":98.0,"wpm":120},{"id":2,"name":"dominus","words_typed":20,"time":14,"mistakes":5,"accuracy":95.0,"wpm":86}]}'
+      )
+    end
+  end
+end


### PR DESCRIPTION
We can represent the stats state that we want to send to the client with
this model. The model holds a hash of players that contains their stats.
This allows us to continue using the pattern that the race position
update uses. This also makes implementation on the client side much
easier because of the similarity.