### PR TITLE
Update UpdatePlayerRoom interactor

### DIFF
--- a/lib/typinggame_server/interactors/players_rooms/update_player_room.rb
+++ b/lib/typinggame_server/interactors/players_rooms/update_player_room.rb
@@ -11,17 +11,30 @@ module Interactors
         @player_room_repository = repository
       end
 
-      def call(player_id:, position:, room_id:)
+      def call(player_id:, position: nil, stats_model: nil, room_id:)
         player_room_record =
           @player_room_repository.find_player_room_records(
             player_id: player_id, room_id: room_id
           )
 
-        @updated_player_room_record =
-          @player_room_repository.update(
-            player_room_record.id,
-            position: position
-          )
+        if position != nil
+          @updated_player_room_record =
+            @player_room_repository.update(
+              player_room_record.id,
+              position: position
+            )
+        end
+
+        if stats_model != nil
+          @updated_player_room_record =
+            @player_room_repository.update(
+              player_room_record.id,
+              words_typed: stats_model.words_typed,
+              time: stats_model.time,
+              mistakes: stats_model.mistakes,
+              letters_typed: stats_model.letters_typed
+            )
+        end
       end
     end
   end

--- a/spec/lib/typinggame_server/interactors/players_rooms/update_player_room_spec.rb
+++ b/spec/lib/typinggame_server/interactors/players_rooms/update_player_room_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Interactors::PlayersRooms::UpdatePlayerRoom do
     described_class.new(repository: repository)
   end
 
-  context 'when the player and room exist' do
+  context 'when given a position update' do
     subject do
       update_player_room_record.call(
         player_id: player.id, position: 30, room_id: room.id
@@ -40,6 +40,39 @@ RSpec.describe Interactors::PlayersRooms::UpdatePlayerRoom do
       expect(subject.updated_player_room_record.player_id).to eq(player.id)
       expect(subject.updated_player_room_record.room_id).to eq(room.id)
       expect(subject.updated_player_room_record.position).to eq(30)
+    end
+  end
+
+  context 'when given a stats update' do
+    let(:stats_model) do
+      Websocket::Interactor::Model::StatsUpdate.new(
+        id: 1,
+        uuid: '25b26b4e-b0c2-49b0-bb06-3dc707cb7c6c',
+        name: 'octane',
+        words_typed: 3,
+        time: 1,
+        mistakes: 0,
+        letters_typed: 10
+      )
+    end
+
+    before do
+      create_player_room_record.call(player_id: player.id, room_id: room.id)
+    end
+
+    subject do
+      update_player_room_record.call(
+        player_id: player.id, stats_model: stats_model, room_id: room.id
+      )
+    end
+
+    it 'updates the players stats specified in the data and room' do
+      expect(subject.updated_player_room_record.player_id).to eq(player.id)
+      expect(subject.updated_player_room_record.room_id).to eq(room.id)
+      expect(subject.updated_player_room_record.letters_typed).to eq(10)
+      expect(subject.updated_player_room_record.mistakes).to eq(0)
+      expect(subject.updated_player_room_record.time).to eq(1)
+      expect(subject.updated_player_room_record.words_typed).to eq(3)
     end
   end
 end


### PR DESCRIPTION
Now that we aren't only updating players' positions but also their
stats in a room, we need to update our player_room entities in different
ways.

This allows us to send this interactor different things to achieve
different results, but we might want to separate this into two different
interactors to be more explicit and separate concerns.