### PR TITLE
Implement StatsUpdate service

### DIFF
--- a/lib/middleware/websocket/interactors/updates/stats_update.rb
+++ b/lib/middleware/websocket/interactors/updates/stats_update.rb
@@ -1,0 +1,58 @@
+require './lib/middleware/websocket/interactors/models/states/stats_state'
+require './lib/typinggame_server/interactors/players_rooms/fetch_players_names_stats'
+
+module Websocket
+  module Interactor
+    class StatsUpdate
+      def call(connection:, room_id:, update_model:)
+        players = build_players(room_id: room_id)
+        connection.publish "#{room_id}",
+                           "#{Model::StatsState.new(players: players).to_json}"
+      end
+
+      private
+
+      def build_players(room_id:)
+        players_names_stats = fetch_players_names_stats(room_id: room_id)
+        players =
+          players_names_stats.map do |player|
+            {
+              'id' => player[:player_id],
+              'name' => player[:name],
+              'words_typed' => player[:words_typed],
+              'time' => player[:time],
+              'mistakes' => player[:mistakes],
+              'accuracy' =>
+                calculate_accuracy(
+                  letters_typed: player[:letters_typed],
+                  mistakes: player[:mistakes]
+                ),
+              'wpm' =>
+                calculate_wpm(
+                  letters_typed: player[:letters_typed], time: player[:time]
+                )
+            }
+          end
+      end
+
+      def fetch_players_names_stats(room_id:)
+        Interactors::PlayersRooms::FetchPlayersNamesStats.new.call(
+          room_id: room_id
+        )
+          .players_names_stats
+      end
+
+      def calculate_wpm(letters_typed:, time:)
+        average_word_length = 5
+        (letters_typed / average_word_length / (time.to_f / 60)).round
+      end
+
+      def calculate_accuracy(letters_typed:, mistakes:)
+        accuracy =
+          (((letters_typed.to_f - mistakes) / letters_typed) * 100).round(1)
+
+        accuracy < 0 ? 0 : accuracy
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/updates/stats_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/stats_update_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::StatsUpdate do
+  let(:connection) { double('connection') }
+  let(:player_attributes_1) { { 'id' => 1, 'name' => 'octane' } }
+  let(:team_1) { { 'id' => 'X0klA3' } }
+  let(:access_token_1) { 'fdgdfg908g9n9gf09fgh8' }
+  let(:player_attributes_2) { { 'id' => 2, 'name' => 'dominus' } }
+  let(:team_2) { { 'id' => 'Ie034K' } }
+  let(:access_token_2) { 'fdasdgsfgfng9gf09fghg' }
+
+  let(:player_1) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes_1,
+      team: team_1,
+      access_token: access_token_1
+    )
+      .player
+  end
+  let(:player_2) do
+    Interactors::Players::CreatePlayer.new.call(
+      player_attributes: player_attributes_2,
+      team: team_2,
+      access_token: access_token_2
+    )
+      .player
+  end
+  let(:room) { Interactors::Rooms::CreateRoom.new.call.room }
+  let(:create_player_room_record) do
+    Interactors::PlayersRooms::CreatePlayerRoom.new
+  end
+  let(:update_model_1) do
+    Websocket::Interactor::Model::StatsUpdate.new(
+      id: player_1.id,
+      uuid: '25b26b4e-b0c2-49b0-bb06-3dc707cb7c6c',
+      name: 'octane',
+      words_typed: 3,
+      time: 1,
+      mistakes: 0,
+      letters_typed: 10
+    )
+  end
+  let(:update_model_2) do
+    Websocket::Interactor::Model::StatsUpdate.new(
+      id: player_2.id,
+      uuid: '25b26b4e-b0c2-49b0-bb06-5bg707xr3j4j',
+      name: 'dominus',
+      words_typed: 3,
+      time: 3,
+      mistakes: 1,
+      letters_typed: 10
+    )
+  end
+
+  describe '#call' do
+    context 'the first player finishes' do
+      subject do
+        described_class.new.call(
+          connection: connection, room_id: room.id, update_model: update_model_1
+        )
+      end
+
+      before do
+        create_player_room_record.call(player_id: player_1.id, room_id: room.id)
+        create_player_room_record.call(player_id: player_2.id, room_id: room.id)
+        Interactors::PlayersRooms::UpdatePlayerRoom.new.call(
+          player_id: player_1.id, stats_model: update_model_1, room_id: room.id
+        )
+      end
+
+      it 'publishes a stats payload to the specified room' do
+        expect(connection).to receive(:publish).with(
+          "#{room.id}",
+          "{\"type\":\"stats\",\"players\":[{\"id\":#{
+            player_1.id
+          },\"name\":\"octane\",\"words_typed\":3,\"time\":1,\"mistakes\":0,\"accuracy\":100.0,\"wpm\":120}]}"
+        )
+        subject
+      end
+    end
+
+    context 'the second player finishes' do
+      subject do
+        described_class.new.call(
+          connection: connection, room_id: room.id, update_model: update_model_2
+        )
+      end
+
+      before do
+        create_player_room_record.call(player_id: player_1.id, room_id: room.id)
+        create_player_room_record.call(player_id: player_2.id, room_id: room.id)
+        Interactors::PlayersRooms::UpdatePlayerRoom.new.call(
+          player_id: player_1.id, stats_model: update_model_1, room_id: room.id
+        )
+        Interactors::PlayersRooms::UpdatePlayerRoom.new.call(
+          player_id: player_2.id, stats_model: update_model_2, room_id: room.id
+        )
+      end
+
+      it 'publishes a stats payload to the specified room' do
+        expect(connection).to receive(:publish).with(
+          "#{room.id}",
+          "{\"type\":\"stats\",\"players\":[{\"id\":#{
+            player_1.id
+          },\"name\":\"octane\",\"words_typed\":3,\"time\":1,\"mistakes\":0,\"accuracy\":100.0,\"wpm\":120},{\"id\":#{
+            player_2.id
+          },\"name\":\"dominus\",\"words_typed\":3,\"time\":3,\"mistakes\":1,\"accuracy\":90.0,\"wpm\":40}]}"
+        )
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
To send the state of all players' stats that are in a room we need to
perform some calculations separate from other services.

We use our stats_state model to build the payload and publish it to all
in the room so that they can render all players stats who are finished
playing the game