### PR TITLE
Add columns to rooms table

### DIFF
--- a/db/migrations/20190809225655_create_rooms.rb
+++ b/db/migrations/20190809225655_create_rooms.rb
@@ -1,0 +1,11 @@
+Hanami::Model.migration do
+  change do
+    alter_table :rooms do
+      add_column :created_at, DateTime, null: false
+      add_column :updated_at, DateTime, null: false
+      add_column :game_started, :boolean, default: false
+
+      drop_column :players
+    end
+  end
+end


### PR DESCRIPTION
We need to stop players from joining games that are in progress. We
already have ways of knowing when a game has been started, so we can
just latch onto those to use this column and deny and late comers to a
game.

We can also use the updated_at column to expire rooms as well so that
you can't go back and play old games to get better stats.

The :players column in this table doesn't actually do anything and was added way back when, we don't need it.