### PR TITLE
Implement game_started feature

### DIFF
--- a/lib/middleware/websocket/interactors/handlers/handle_countdown_update.rb
+++ b/lib/middleware/websocket/interactors/handlers/handle_countdown_update.rb
@@ -1,11 +1,21 @@
 require './lib/middleware/websocket/interactors/updates/countdown_update'
+require './lib/typinggame_server/interactors/rooms/update_room'
 
 module Websocket
   module Interactor
     module Handler
       class HandleCountdownUpdate
         def call(connection:, room_id:)
+          start_game(room_id: room_id, game_started: true)
           CountdownUpdate.new.call(connection: connection, room_id: room_id)
+        end
+
+        private
+
+        def start_game(room_id:, game_started:)
+          Interactors::Rooms::UpdateRoom.new.call(
+            room_id: room_id, game_started: game_started
+          )
         end
       end
     end

--- a/lib/middleware/websocket/interactors/handlers/handle_join_update.rb
+++ b/lib/middleware/websocket/interactors/handlers/handle_join_update.rb
@@ -1,5 +1,6 @@
 require './lib/middleware/websocket/interactors/updates/join_update'
 require './lib/middleware/websocket/interactors/updates/race_update'
+require './lib/middleware/websocket/interactors/updates/room_update'
 require './lib/typinggame_server/interactors/players/fetch_player'
 require './lib/typinggame_server/interactors/rooms/fetch_room'
 require './lib/typinggame_server/interactors/players_rooms/create_player_room'
@@ -15,6 +16,9 @@ module Websocket
 
           player = fetch_player(uuid: uuid)
           room = fetch_room(id: room_id)
+
+          return if game_started?(room: room, connection: connection)
+
           connection.subscribe "#{room.id}"
 
           build_association(player_id: player.id, room_id: room.id)
@@ -65,6 +69,16 @@ module Websocket
               .player_room_record
 
           !player_room_record.nil?
+        end
+
+        def game_started?(room:, connection:)
+          if room.game_started
+            RoomUpdate.new.call(
+              connection: connection, game_started: room.game_started
+            )
+          end
+
+          room.game_started
         end
       end
     end

--- a/lib/middleware/websocket/interactors/models/states/room_state.rb
+++ b/lib/middleware/websocket/interactors/models/states/room_state.rb
@@ -1,0 +1,18 @@
+module Websocket
+  module Interactor
+    module Model
+      class RoomState
+        attr_reader :type, :game_started
+
+        def initialize(game_started:)
+          @type = 'game_started'
+          @game_started = game_started
+        end
+
+        def to_json
+          { type: @type, game_started: @game_started }.to_json
+        end
+      end
+    end
+  end
+end

--- a/lib/middleware/websocket/interactors/updates/room_update.rb
+++ b/lib/middleware/websocket/interactors/updates/room_update.rb
@@ -1,0 +1,13 @@
+require './lib/middleware/websocket/interactors/models/states/room_state'
+
+module Websocket
+  module Interactor
+    class RoomUpdate
+      def call(connection:, game_started:)
+        connection.write(
+          Model::RoomState.new(game_started: game_started).to_json
+        )
+      end
+    end
+  end
+end

--- a/lib/typinggame_server/interactors/rooms/create_room.rb
+++ b/lib/typinggame_server/interactors/rooms/create_room.rb
@@ -12,7 +12,7 @@ module Interactors
       end
 
       def call
-        @room = @rooms_repository.create(players: 0)
+        @room = @rooms_repository.create(game_started: false)
       end
     end
   end

--- a/lib/typinggame_server/interactors/rooms/update_room.rb
+++ b/lib/typinggame_server/interactors/rooms/update_room.rb
@@ -1,0 +1,20 @@
+require 'hanami/interactor'
+
+module Interactors
+  module Rooms
+    class UpdateRoom
+      include Hanami::Interactor
+
+      expose :updated_room
+
+      def initialize(repository: RoomRepository.new)
+        @rooms_repository = repository
+      end
+
+      def call(room_id:, game_started:)
+        @updated_room =
+          @rooms_repository.update(room_id, game_started: game_started)
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/models/states/room_state_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/models/states/room_state_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::Model::RoomState do
+  let(:room_state_payload) { described_class.new(game_started: true) }
+
+  describe '.to_json' do
+    subject { room_state_payload.to_json }
+
+    it 'builds a json payload' do
+      expect(subject).to eq('{"type":"game_started","game_started":true}')
+    end
+  end
+end

--- a/spec/lib/middleware/websocket/interactors/updates/room_update_spec.rb
+++ b/spec/lib/middleware/websocket/interactors/updates/room_update_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Websocket::Interactor::RoomUpdate do
+  let(:connection) { double('connection') }
+
+  describe '#call' do
+    subject do
+      described_class.new.call(connection: connection, game_started: true)
+    end
+
+    it 'sends the connection a game_started update' do
+      expect(connection).to receive(:write).with(
+        '{"type":"game_started","game_started":true}'
+      )
+      subject
+    end
+  end
+end

--- a/spec/lib/typinggame_server/interactors/rooms/update_room_spec.rb
+++ b/spec/lib/typinggame_server/interactors/rooms/update_room_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Interactors::Rooms::UpdateRoom do
+  let(:repository) { RoomRepository.new }
+  let(:update_room) { described_class.new(repository: repository) }
+
+  context 'starting the game' do
+    let(:result) { update_room.call(room_id: 1, game_started: true) }
+
+    before { repository.create(id: '1') }
+
+    it 'succeeds' do
+      expect(result.successful?).to be(true)
+    end
+
+    it 'updates the game_started column' do
+      expect(result.updated_room.game_started).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
We need to disallow players from joining rooms where games are already being played, as well as disallow players from joining old games where they would be able to change their stats.

To achieve this we simply don't allow anything to happen when a player joins a room in progress.